### PR TITLE
Enriquece textos de novidades

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -374,11 +374,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -396,7 +398,8 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
@@ -528,6 +531,7 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -539,6 +543,7 @@
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -646,6 +651,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3027,6 +3033,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
+    },
+    "@types/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-hkgzYF+qnIl8uTO8rmUSVSfQ8BIfMXC4yJAF4n8BE758YsKBZvFC4NumnAegj7KmylP0liEZNpb9RRGFMbFejA=="
     },
     "@types/webpack-sources": {
       "version": "0.1.6",

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "~8.2.12",
     "@angular/router": "~8.2.12",
     "@ng-bootstrap/ng-bootstrap": "^5.0.0",
+    "@types/sprintf-js": "^1.1.2",
     "bootstrap": "^4.4.1",
     "ngx-pagination": "^5.0.0",
     "rxjs": "~6.4.0",

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,6 +1,8 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
+import { CurrencyPipe } from '@angular/common';
+
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -22,6 +24,7 @@ import { NovidadeService } from './shared/services/novidade.service';
     NgbModule
   ],
   providers: [
+    CurrencyPipe,
     UserService,
     NovidadeService
   ],

--- a/client/src/app/novidades/novidade/novidade.component.html
+++ b/client/src/app/novidades/novidade/novidade.component.html
@@ -11,7 +11,7 @@
 >
   <div class="card-body">
     <h6>
-      {{ novidade.tipo.texto_evento }}
+      {{ novidadeService.getTextoNovidade(novidade) }}
       <span *ngIf="showMunicipio">em {{ novidade.nome_municipio }}</span>
     </h6>
     <p class="card-text text-muted text-right">

--- a/client/src/app/shared/services/novidade.service.ts
+++ b/client/src/app/shared/services/novidade.service.ts
@@ -1,7 +1,9 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { CurrencyPipe } from '@angular/common';
 
 import { Observable, BehaviorSubject } from 'rxjs';
+import { sprintf } from 'sprintf-js';
 
 import {
   switchMap,
@@ -28,7 +30,9 @@ export class NovidadeService {
   private TIPOS_EMPENHO = [4, 5, 6, 7, 8, 9];
   private TIPOS_CONTRATO = [10, 11];
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private currencyPipe: CurrencyPipe) {
     this.novidades
       .pipe(
         switchMap(novidade =>
@@ -90,6 +94,22 @@ export class NovidadeService {
 
   isContrato(idTipo: number): boolean {
     return this.TIPOS_CONTRATO.includes(idTipo);
+  }
+
+  getTextoNovidade(novidade: Novidade): string {
+    if (this.isLicitacao(novidade.id_tipo)) {
+      return sprintf(novidade.tipo.texto_evento,
+        novidade.licitacaoNovidade.nr_licitacao + '/' + novidade.licitacaoNovidade.ano_licitacao);
+    } else if (this.isEmpenho(novidade.id_tipo)) {
+      return sprintf(novidade.tipo.texto_evento,
+        this.currencyPipe.transform(novidade.texto_novidade, 'R$ '),
+        novidade.licitacaoNovidade.nr_licitacao + '/' + novidade.licitacaoNovidade.ano_licitacao);
+    } else if (this.isContrato(novidade.id_tipo)) {
+      return sprintf(novidade.tipo.texto_evento,
+        novidade.texto_novidade,
+        novidade.licitacaoNovidade.nr_licitacao + '/' + novidade.licitacaoNovidade.ano_licitacao);
+    }
+    return novidade.tipo.texto_evento;
   }
 
   /**


### PR DESCRIPTION
# Mudanças

- Cria um método no serviço de novidades para melhorar o texto das mesmas.
- De acordo com o tipo de novidade, inclui os dados auxiliares ao texto do tipo de novidade.
- É necessário que o texto do tipo de novidade no banco de dados tenha os caracteres reservados para substituição (%s)

Ex.: Empenho de %s da licitação %s -> Empenho de R$ 500.00 da licitação 01/2020