### PR TITLE
Corrige endpoint de novidades para mostrar novidades de todos os municípios

### DIFF
--- a/server/middlewares/novidades.validator.js
+++ b/server/middlewares/novidades.validator.js
@@ -31,12 +31,6 @@ module.exports = {
             throw new Error("Data Final está num formato inválido. Formato correto: YYYY-MM-DD");
         }
         return true;
-      }),
-      check('nome_municipio').custom((nome_municipio) => {
-        if (nome_municipio === undefined || nome_municipio === "") {
-          throw new Error("O parâmetro nome_municipio não pode ser vazio.");
-        }
-        return true;
       })
     ]  
 };


### PR DESCRIPTION
## Mudanças
- Corrige endpoint de novidades para mostrar novidades de todos os municípios
- Estabelece um limite de 1000 novidades caso não sejam mostradas novidades de um município específico
- Closes #49 