### PR TITLE
Modifica aba de contratos para incluir fornecedor

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -6,8 +6,8 @@
     activeIds="ngb-panel-0"
     [closeOthers]="true">
     <ngb-panel
-      [title]="'Contrato ' + contrato.nr_contrato"
-      *ngFor="let contrato of licitacao?.contratosLicitacao; index as i">
+      [title]="contrato?.contratoFornecedor?.nm_pessoa !== null ? 'Contrato ' + contrato?.nr_contrato + ' - ' + contrato?.contratoFornecedor?.nm_pessoa : 'Contrato ' + contrato?.nr_contrato"
+      *ngFor="let contrato of contratoLicitacao; index as i">
       <ng-template ngbPanelContent>
 
         <div class="dados-grupo">
@@ -22,8 +22,15 @@
             </span>
           </div>
           <div class="dados-linha">
-            <strong>Documento:&nbsp;</strong>
-            <span class="text-muted">{{ contrato?.nr_documento_contratado }}</span>
+            <strong>Fornecedor:&nbsp;</strong>
+            <span *ngIf="contrato?.contratoFornecedor?.nm_pessoa !== null" class="text-muted">
+              {{ contrato?.nr_documento_contratado }} - {{ contrato?.contratoFornecedor?.nm_pessoa }}</span>
+            <span *ngIf="contrato?.contratoFornecedor?.nm_pessoa === null" class="text-muted">
+              {{ contrato?.nr_documento_contratado }} (Nome não encontrado)</span>
+          </div>
+          <div class="dados-linha">
+            <strong>Tipo de Fornecedor:&nbsp;</strong>
+            <span class="text-muted">{{ getTipoFornecedor(contrato?.contratoFornecedor?.tp_pessoa) }}</span>
           </div>
         </div>
         <div class="table-responsive">
@@ -38,7 +45,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr *ngFor="let item of contrato.itensContrato; index as i">
+              <tr *ngFor="let item of contrato?.itensContrato; index as i">
                 <th scope="row">{{ i + 1 }}</th>
                 <td>
                   <button

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
@@ -5,7 +5,7 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subject } from 'rxjs';
 import { takeUntil, take } from 'rxjs/operators';
 
-import { Licitacao } from 'src/app/shared/models/licitacao.model';
+import { ContratoLicitacao } from 'src/app/shared/models/contratoLicitacao.model';
 import { LicitacaoService } from 'src/app/shared/services/licitacao.service';
 
 @Component({
@@ -17,7 +17,7 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
 
   private unsubscribe = new Subject();
 
-  public licitacao: Licitacao;
+  public contratoLicitacao: ContratoLicitacao;
   public descricao: string;
 
   constructor(
@@ -27,15 +27,15 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.activatedroute.parent.params.pipe(take(1)).subscribe(params => {
-      this.getLicitacaoByID(params.id);
+      this.getContratosLicitacaoByID(params.id);
     });
   }
 
-  getLicitacaoByID(id: string) {
-    this.licitacaoService.get(id)
+  getContratosLicitacaoByID(id: string) {
+    this.licitacaoService.getContratos(id)
       .pipe(takeUntil(this.unsubscribe))
-      .subscribe(licitacao => {
-        this.licitacao = licitacao;
+      .subscribe(contratosLicitacao => {
+        this.contratoLicitacao = contratosLicitacao;
       });
   }
 
@@ -43,9 +43,20 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
     return descricao.split(/\s+|:/)[0];
   }
 
+  getTipoFornecedor(tipoFornecedor: string): string {
+    if (tipoFornecedor === 'J') {
+      return 'Pessoa Jurídica';
+    } else if (tipoFornecedor === 'F') {
+      return 'Pessoa Física';
+    } else if (tipoFornecedor === 'C') {
+      return 'Consórcio';
+    }
+    return 'Outros';
+  }
+
   open(content, descricao: string): void {
     this.descricao = descricao;
-    this.modalService.open(content, { ariaLabelledBy: 'modal-descricao'});
+    this.modalService.open(content, { ariaLabelledBy: 'modal-descricao' });
   }
 
   ngOnDestroy() {

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
@@ -17,7 +17,7 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
 
   private unsubscribe = new Subject();
 
-  public contratoLicitacao: ContratoLicitacao;
+  public contratoLicitacao: ContratoLicitacao[];
   public descricao: string;
 
   constructor(

--- a/client/src/app/shared/models/contratoLicitacao.model.ts
+++ b/client/src/app/shared/models/contratoLicitacao.model.ts
@@ -1,0 +1,10 @@
+import { ItensContrato } from './itensContrato.model';
+import { Fornecedor } from './fornecedor.model';
+
+export interface ContratoLicitacao {
+  nr_contrato: number;
+  nr_documento_contratatado: string;
+  vl_contrato: number;
+  contratoFornecedor: Fornecedor;
+  itensContrato: ItensContrato[];
+}

--- a/client/src/app/shared/models/fornecedor.model.ts
+++ b/client/src/app/shared/models/fornecedor.model.ts
@@ -1,0 +1,4 @@
+export interface Fornecedor {
+    nm_pessoa: string;
+    tp_pessoa: string;
+}

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -1,0 +1,6 @@
+export interface ItensContrato {
+  qt_itens_contrato: number;
+  vl_item_contrato: number;
+  vl_total_item_contrato: number;
+  ds_item: string;
+}

--- a/client/src/app/shared/models/licitacao.model.ts
+++ b/client/src/app/shared/models/licitacao.model.ts
@@ -14,5 +14,4 @@ export interface Licitacao {
   vl_homologado: number;
   descricao_objeto: string;
   itensLicitacao: ItensLicitacao[];
-  contratosLicitacao: any;
 }

--- a/client/src/app/shared/services/licitacao.service.ts
+++ b/client/src/app/shared/services/licitacao.service.ts
@@ -23,8 +23,8 @@ export class LicitacaoService {
   }
 
   // Recupera contratos de uma licitação
-  getContratos(id: string): Observable<ContratoLicitacao> {
-    return this.http.get<ContratoLicitacao>(this.urlContratos + '/licitacao/' + id);
+  getContratos(id: string): Observable<ContratoLicitacao[]> {
+    return this.http.get<ContratoLicitacao[]>(this.urlContratos + '/licitacao/' + id);
   }
 
 }

--- a/client/src/app/shared/services/licitacao.service.ts
+++ b/client/src/app/shared/services/licitacao.service.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Licitacao } from '../models/licitacao.model';
+import { ContratoLicitacao } from '../models/contratoLicitacao.model';
 
 import { environment } from '../../../environments/environment';
 
@@ -13,11 +14,17 @@ import { environment } from '../../../environments/environment';
 export class LicitacaoService {
 
   private url = environment.apiUrl + 'licitacoes';
+  private urlContratos = environment.apiUrl + 'contratos';
 
   constructor(private http: HttpClient) { }
 
   get(id: string): Observable<Licitacao> {
     return this.http.get<Licitacao>(this.url + '/' + id);
+  }
+
+  // Recupera contratos de uma licitação
+  getContratos(id: string): Observable<ContratoLicitacao> {
+    return this.http.get<ContratoLicitacao>(this.urlContratos + '/licitacao/' + id);
   }
 
 }

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -7,6 +7,7 @@ const tipoNovidadeModel = "./postgres/tipoNovidade.js";
 const itensLicitacaoModel = "./postgres/itensLicitacao.js";
 const contratoModel = "./postgres/contrato.js";
 const itensContratoModel = "./postgres/itensContrato.js"
+const fornecedorModel = "./postgres/fornecedor.js"
 
 if (!global.hasOwnProperty("models")) {
   const db = process.env.POSTGRESURI;
@@ -36,7 +37,8 @@ if (!global.hasOwnProperty("models")) {
     tipoNovidade: sequelize.import(tipoNovidadeModel),
     itensLicitacao: sequelize.import(itensLicitacaoModel),
     contrato: sequelize.import(contratoModel),
-    itensContrato: sequelize.import(itensContratoModel)
+    itensContrato: sequelize.import(itensContratoModel),
+    fornecedor: sequelize.import(fornecedorModel)
     //add your others models here
   };
 

--- a/server/models/postgres/contrato.js
+++ b/server/models/postgres/contrato.js
@@ -46,6 +46,11 @@ module.exports = (sequelize, type) => {
         foreignKey: "id_licitacao",
         sourceKey: "id_licitacao",
         as: "contratosLicitacao"
+      });
+      contrato.belongsTo(models.fornecedor, {
+        foreignKey: "nr_documento_contratado",
+        sourceKey: "nr_documento",
+        as: "contratoFornecedor"
       }); 
       contrato.hasMany(models.itensContrato, {
         foreignKey: "id_contrato",

--- a/server/models/postgres/fornecedor.js
+++ b/server/models/postgres/fornecedor.js
@@ -1,0 +1,26 @@
+module.exports = (sequelize, type) => {
+  fornecedor = sequelize.define(
+    "fornecedor",
+    {
+      nr_documento: {
+        type: type.STRING,
+        primaryKey: true
+      },
+      nm_pessoa: type.STRING,
+      tp_pessoa: type.STRING
+    },
+    {
+      freezeTableName: true,
+      timestamps: false
+    }
+  );
+
+  fornecedor.associate = function (models) {
+    fornecedor.hasMany(models.contrato, {
+      foreignKey: "nr_documento_contratado",
+      targetKey: "nr_documento",
+      as: "fornecedorContratos"
+    });
+  };
+  return fornecedor;
+}

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -5,6 +5,7 @@ const router = express.Router();
 const models = require("../../models/index");
 
 const Contrato = models.contrato;
+const Fornecedor = models.fornecedor;
 
 const BAD_REQUEST = 400;
 const SUCCESS = 200;
@@ -27,6 +28,19 @@ router.get("/:id", (req, res) => {
 
 router.get("/licitacao/:id", (req, res) => {
   Contrato.findAll({
+    attributes: ["nr_contrato", "nr_documento_contratado", "vl_contrato"],
+    include: [
+      {
+        model: Fornecedor,
+        attributes: ["nm_pessoa", "tp_pessoa"],
+        as: "contratoFornecedor"
+      },
+      {
+        model: itensContrato,
+        attributes: ["qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item"],
+        as: "itensContrato"
+      }
+    ],
     where: {
       id_licitacao: req.params.id
     }

--- a/server/routes/api/licitacoes.js
+++ b/server/routes/api/licitacoes.js
@@ -25,18 +25,6 @@ router.get("/:id", (req, res) => {
         model: itensLicitacao,
         attributes: ["ds_item", "qt_itens_licitacao", "sg_unidade_medida", "vl_unitario_estimado", "vl_total_estimado"],
         as: "itensLicitacao"
-      },
-      {
-        model: Contrato,
-        include: [
-          {
-            model: itensContrato,
-            attributes: ["qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item"],
-            as: "itensContrato"
-          }
-        ],
-        attributes: ["nr_contrato", "nr_documento_contratado", "vl_contrato"],
-        as: "contratosLicitacao"
       }
     ],
     where: {


### PR DESCRIPTION
## Mudanças
- Adicionar model de fornecedor
- Modifica endpoint para recuperar contratos de uma licitação (incluindo informações de fornecedores)
- Cria models no frontend para fornecedor e contrato de uma licitação
- Exibe nome e tipo do fornecedor na aba de contratos

## Flags
- É preciso ter os dados gerados pela versão do módulo de dados: https://github.com/analytics-ufcg/ta-na-mesa-dados/pull/49
- Também é possível baixar os dados já processados disponibilizados em: https://www.dropbox.com/sh/tkvtvisavcqydcs/AAA6tcxMMu25A97vXsZmZaIra?dl=0