### PR TITLE
Cria uma URL diferente para cada tipo de novidade

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -3,9 +3,10 @@
 
   <ngb-accordion
     #acc="ngbAccordion"
-    activeIds="ngb-panel-0"
+    [activeIds]="activeIds"
     [closeOthers]="true">
     <ngb-panel
+      id="panel-{{ contrato?.id_contrato }}"
       [title]="contrato?.contratoFornecedor?.nm_pessoa !== null ? 'Contrato ' + contrato?.nr_contrato + ' - ' + contrato?.contratoFornecedor?.nm_pessoa : 'Contrato ' + contrato?.nr_contrato"
       *ngFor="let contrato of contratoLicitacao; index as i">
       <ng-template ngbPanelContent>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbAccordion } from '@ng-bootstrap/ng-bootstrap';
 import { Subject } from 'rxjs';
 import { takeUntil, take } from 'rxjs/operators';
 
@@ -19,6 +19,7 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
 
   public contratoLicitacao: ContratoLicitacao[];
   public descricao: string;
+  public activeIds: string[] = [];
 
   constructor(
     private activatedroute: ActivatedRoute,
@@ -28,6 +29,9 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.activatedroute.parent.params.pipe(take(1)).subscribe(params => {
       this.getContratosLicitacaoByID(params.id);
+    });
+    this.activatedroute.queryParams.pipe(take(1)).subscribe(params => {
+      this.activeIds = ['panel-' + params.id];
     });
   }
 

--- a/client/src/app/novidades/novidade/novidade.component.ts
+++ b/client/src/app/novidades/novidade/novidade.component.ts
@@ -17,7 +17,17 @@ export class NovidadeComponent {
   constructor(private router: Router, public novidadeService: NovidadeService) { }
 
   handleClick() {
-    this.router.navigate(['/licitacoes/' + this.novidade.licitacaoNovidade.id_licitacao]);
+    if (this.novidadeService.isContrato(this.novidade.id_tipo)) {
+      this.router.navigate(['/licitacoes/' + this.novidade.licitacaoNovidade.id_licitacao + '/contratos'],
+        { queryParams: { id: this.novidade.id_original }
+      });
+    } else if (this.novidadeService.isEmpenho(this.novidade.id_tipo)) {
+      this.router.navigate(['/licitacoes/' + this.novidade.licitacaoNovidade.id_licitacao + '/info'],
+        { queryParams: { id: this.novidade.id_original }
+      });
+    } else {
+      this.router.navigate(['/licitacoes/' + this.novidade.licitacaoNovidade.id_licitacao]);
+    }
   }
 
 }

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -28,7 +28,7 @@ router.get("/:id", (req, res) => {
 
 router.get("/licitacao/:id", (req, res) => {
   Contrato.findAll({
-    attributes: ["nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia"],
+    attributes: ["id_contrato", "nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia"],
     include: [
       {
         model: Fornecedor,


### PR DESCRIPTION
## Mudanças

- A URL ao clicar em alguma novidade deve refletir o tipo de novidade:
- Se for licitação -> leva para a rota padrão: /licitacao/:id
- Se for contrato -> leva para a rota /licitacao/:id/contrato?id=<id_contrato> e abre o contrato referido
- Se for empenho -> leva para a rota padrão com id do empenho: /licitacao/:id?id=<id_empenho>. Ainda não há nenhuma interação com a interface pois depende da aprovação da timeline

## Flags

Funciona com a branch master dos dados
