### PR TITLE
Usa view para realizar consulta de similares

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
@@ -61,23 +61,22 @@ export class LicitacoesDetalharContratosComponent implements OnInit, OnDestroy {
             const tituloItem = item.ds_item.split(/\s+|:|-/).slice(0, 3).map(palavra => {
               return palavra.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '');
             }).filter(i => i !== '');
-            this.getMediaItensSemelhantes(tituloItem, item.ano_licitacao).then(mediana => {
-              item.mediana_valor = mediana;
-            });
+            this.getMediaItensSemelhantes(tituloItem, item.dt_inicio_vigencia)
+              .then(mediana => {
+                item.mediana_valor = mediana;
+              });
           });
         });
         this.isLoading = false;
       });
   }
 
-  getMediaItensSemelhantes(dsItem: string[], ano: number) {
+  getMediaItensSemelhantes(dsItem: string[], dataInicioContrato: Date) {
     const termos = [dsItem[0], dsItem.slice(0, 2).join(' & '), dsItem.join(' & ')];
-    return this.itensService.getItensSimilares(termos)
+    return this.itensService.getItensSimilares(termos, dataInicioContrato)
       .pipe(take(1),
         map(item => {
-          const itensOrdenados = item.filter(d => {
-            return d.ano_licitacao === ano;
-          }).slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
+          const itensOrdenados = item.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
           const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
           const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
           const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -8,4 +8,5 @@ export interface ItensContrato {
   vl_item_contrato: number;
   vl_total_item_contrato: number;
   ds_item: string;
+  dt_inicio_vigencia: Date;
 }

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -18,8 +18,8 @@ export class ItensService {
 
     constructor(private http: HttpClient) { }
 
-    getItensSimilares(nomeItem: string[]): Observable<ItensContrato[]> {
-        return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: nomeItem });
+    getItensSimilares(nomeItem: string[], dataInicioContrato: Date): Observable<ItensContrato[]> {
+        return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: nomeItem, data: dataInicioContrato });
     }
 
 }

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -56,7 +56,7 @@ router.get("/licitacao/:id", (req, res) => {
             as: "itensSemelhantes"
           }
         ],
-        attributes: ["qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item", "categoria", "ano_licitacao"],
+        attributes: ["qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item", "categoria", "ano_licitacao", "dt_inicio_vigencia"],
         as: "itensContrato"
       }
     ],

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -40,11 +40,11 @@ router.get("/licitacao/:id", (req, res) => {
 });
 
 router.post("/similares", (req, res) => {
-  let first_part = "SELECT * FROM ( SELECT *, setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_1),'A') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_2),'C') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_3),'D') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_item),'D') AS document FROM item_contrato) p_search WHERE   p_search.document @@ to_tsquery('portuguese','";
+  let first_part = "SELECT ano_licitacao, id_item_contrato, id_licitacao, vl_item_contrato, vl_total_item_contrato, ds_item FROM ( SELECT *, setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_1),'A') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_2),'C') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_3),'D') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_item),'D') AS document FROM item_contrato) p_search WHERE   p_search.document @@ to_tsquery('portuguese','";
   let ranking = "') ORDER BY ts_rank(p_search.document, to_tsquery('portuguese','";
-  let end = "')) DESC;";
+  let end = "')) DESC LIMIT 100;";
   
-  models.sequelize.query(first_part.concat(req.body.termo.join(' | '), ranking, req.body.termo[2], end), {
+  models.sequelize.query(first_part.concat(req.body.termo.join(' | '), ranking, req.body.termo[0], end), {
     model: itensContrato,
     mapToModel: true
   }).then(itensContrato => res.status(SUCCESS).json(itensContrato))

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -40,11 +40,28 @@ router.get("/licitacao/:id", (req, res) => {
 });
 
 router.post("/similares", (req, res) => {
-  let first_part = "SELECT ano_licitacao, id_item_contrato, id_licitacao, vl_item_contrato, vl_total_item_contrato, ds_item FROM ( SELECT *, setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_1),'A') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_2),'C') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_3),'D') || setweight(to_tsvector(item_contrato.language :: regconfig,item_contrato.ds_item),'D') AS document FROM item_contrato) p_search WHERE   p_search.document @@ to_tsquery('portuguese','";
-  let ranking = "') ORDER BY ts_rank(p_search.document, to_tsquery('portuguese','";
-  let end = "')) DESC LIMIT 100;";
+
+  const dataInicioContrato = req.body.data;
+  const termo = req.body.termo.join(' | ')
+  const termoRanking = req.body.termo[0]
+
+  dataInicial = new Date(dataInicioContrato);
+  dataInicial.setMonth(dataInicial.getMonth() - 6);
+
+  dataFinal = new Date(dataInicioContrato);
+  dataFinal.setMonth(dataFinal.getMonth() + 6);
+
+  dataInicial = dataInicial.toJSON().slice(0, 10);
+  dataFinal = dataFinal.toJSON().slice(0, 10);
+    
+  let query = `SELECT ano_licitacao, id_item_contrato, id_licitacao, vl_item_contrato, \
+                      vl_total_item_contrato, ds_item, dt_inicio_vigencia FROM \
+                      item_search WHERE item_search.document @@ to_tsquery('portuguese', '${termo}') AND \
+                      dt_inicio_vigencia >= '${dataInicial}' AND dt_inicio_vigencia <= '${dataFinal}'\
+                      ORDER BY ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}'))\
+                      DESC LIMIT 100;`
   
-  models.sequelize.query(first_part.concat(req.body.termo.join(' | '), ranking, req.body.termo[0], end), {
+  models.sequelize.query(query, {
     model: itensContrato,
     mapToModel: true
   }).then(itensContrato => res.status(SUCCESS).json(itensContrato))


### PR DESCRIPTION
## Mudanças
- Usa view materializada para realizar consulta de similares
- Filtra itens retornados dentro de um intervalo de tempo. Os itens similares tem a data de seus contratos entre 6 meses antes e 6 meses depois da data de contrato do item a ser pesquisado.
- Remove filtro de ano realizado no frontend

## Flags
- Depende da revisão do PR https://github.com/analytics-ufcg/ta-na-mesa-dados/pull/59