### PR TITLE
Adiciona o nome do município na tabela de itens similares

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -419,12 +419,12 @@
             <tr>
               <th
                 scope="col"
-                class="text-left align-middle">
+                class="align-middle">
                 Itens similares
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-left">
+                class="table-th-monospace">
                 Município
               </th>
               <th

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -424,6 +424,11 @@
               </th>
               <th
                 scope="col"
+                class="table-th-monospace text-left">
+                Município
+              </th>
+              <th
+                scope="col"
                 class="table-th-monospace text-right">
                 Valor por
                 <br>
@@ -452,6 +457,9 @@
                   <summary>{{ item.ds_item | resumirTexto }}...</summary>
                   <p>{{ item.ds_item }}</p>
                 </details>
+              </td>
+              <td class="align-middle">
+                {{ item.nome_municipio }}
               </td>
               <td class="numero align-middle">
                 {{ item.vl_item_contrato | currency:'':'' }}

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -9,4 +9,5 @@ export interface ItensContrato {
   vl_total_item_contrato: number;
   ds_item: string;
   dt_inicio_vigencia: Date;
+  nome_municipio: string;
 }

--- a/client/src/app/shared/pipes/resumir-texto.pipe.ts
+++ b/client/src/app/shared/pipes/resumir-texto.pipe.ts
@@ -6,7 +6,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class ResumirTextoPipe implements PipeTransform {
 
   transform(descricao: string): string {
-    const tamanho = window.innerWidth <= 500 ? 20 : window.innerWidth / 25; // muda de acordo com o tamanho da tela
+    const tamanho = window.innerWidth <= 500 ? 20 : window.innerWidth / 35; // muda de acordo com o tamanho da tela
     const split = descricao.split(/\s+|:|,/);
     let str = '';
     let i = 0;

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -55,7 +55,7 @@ router.post("/similares", (req, res) => {
   dataFinal = dataFinal.toJSON().slice(0, 10);
     
   let query = `SELECT ano_licitacao, id_item_contrato, id_contrato, id_licitacao, vl_item_contrato, \
-                      vl_total_item_contrato, ds_item, dt_inicio_vigencia \ 
+                      vl_total_item_contrato, ds_item, dt_inicio_vigencia, nome_municipio \ 
                       FROM item_search WHERE item_search.document @@ to_tsquery('portuguese', '${termo}') AND \
                       dt_inicio_vigencia >= '${dataInicial}' AND dt_inicio_vigencia <= '${dataFinal}'\
                       ORDER BY ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) DESC, id_item_contrato ASC \


### PR DESCRIPTION
## Mudanças
- Adiciona o nome do município na tabela de itens similares
- Ajusta parâmetro no pipe de texto reduzido para considerar a nova coluna da tabela de itens similares

## Flags
- Depende da revisão do PR de dados: https://github.com/analytics-ufcg/ta-na-mesa-dados/pull/65