### PR TITLE
309 - Mostrar a média do estado e o valor estimado na licitação e não a diferença

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -109,7 +109,7 @@
                 <th
                   scope="col"
                   class="table-th-monospace table-th-dividido-up text-right">
-                  Valor médio
+                  Mediana
                   <br>
                   no estado
                   <br>
@@ -118,9 +118,9 @@
                 <th
                   scope="col"
                   class="table-th-monospace table-th-percent table-th-dividido-up text-right">
-                  Contrato
+                  Diferença
                   <br>
-                  vs estado
+                  c/ estado
                   <br>
                   (%)
                 </th>
@@ -136,9 +136,9 @@
                 <th
                   scope="col"
                   class="table-th-monospace table-th-percent table-th-dividido-up text-right">
-                  Contratado
+                  Diferença
                   <br>
-                  vs estimado
+                  c/ estimado
                   <br>
                   (%)
                 </th>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -30,7 +30,7 @@
           </div>
           <div class="col-sm-6 col-md-5 col-lg-3 mb-4">
             <div class="dados-linha">
-              <strong>Estimado vs Contratado</strong>
+              <strong>Contratado vs Estimado</strong>
             </div>
             <div class="dados-linha">
               <span *ngIf="contrato?.valor_contratado - contrato?.valor_estimado === 0">--</span>
@@ -136,9 +136,9 @@
                 <th
                   scope="col"
                   class="table-th-monospace table-th-percent table-th-dividido-up text-right">
-                  Pago vs
+                  Contratado
                   <br>
-                  estimado
+                  vs estimado
                   <br>
                   (%)
                 </th>
@@ -164,17 +164,7 @@
                   class="numero align-middle"
                   *ngIf="!radioGroupForm.value['showTotal']"
                   [title]="item.mediana_valor">
-                  <span *ngIf="item.vl_item_contrato - item.mediana_valor === 0">--</span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.mediana_valor < 0"
-                    class="positivo">
-                    {{ item.vl_item_contrato - item.mediana_valor | currency:'':'' }}
-                  </span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.mediana_valor > 0"
-                    class="negativo">
-                    +{{ item.vl_item_contrato - item.mediana_valor | currency:'':'' }}
-                  </span>
+                  {{ item.mediana_valor | currency:'':'' }}
                 </td>
                 <td
                   class="numero align-middle"
@@ -189,24 +179,14 @@
                   <span
                     *ngIf="item.vl_item_contrato - item.mediana_valor > 0"
                     class="negativo">
-                    {{ (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor | percent:'1.1' }}
+                    +{{ (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor | percent:'1.1' }}
                   </span>
                 </td>
                 <td
                   class="numero align-middle"
                   *ngIf="!radioGroupForm.value['showTotal']"
                   [title]="item.itensLicitacaoItensContrato.vl_unitario_estimado">
-                  <span *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado === 0">--</span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado < 0"
-                    class="positivo">
-                    {{ (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) | currency:'':'' }}
-                  </span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado > 0"
-                    class="negativo">
-                    +{{ (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) | currency:'':'' }}
-                  </span>
+                  {{ item.itensLicitacaoItensContrato.vl_unitario_estimado | currency:'':'' }}
                 </td>
                 <td
                   class="numero align-middle"
@@ -221,7 +201,7 @@
                   <span
                     *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado > 0"
                     class="negativo">
-                    {{ (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) / item.itensLicitacaoItensContrato.vl_unitario_estimado | percent:'1.1' }}
+                    +{{ (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) / item.itensLicitacaoItensContrato.vl_unitario_estimado | percent:'1.1' }}
                   </span>
                 </td>
                 <td
@@ -233,17 +213,7 @@
                   class="numero align-middle"
                   *ngIf="radioGroupForm.value['showTotal']"
                   [title]="item.mediana_valor * item.qt_itens_contrato">
-                  <span *ngIf="item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) === 0">--</span>
-                  <span
-                    *ngIf="item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) < 0"
-                    class="positivo">
-                    {{ item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) | currency:'':'' }}
-                  </span>
-                  <span
-                    *ngIf="item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) > 0"
-                    class="negativo">
-                    +{{ item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) | currency:'':'' }}
-                  </span>
+                  {{ item.mediana_valor * item.qt_itens_contrato | currency:'':'' }}
                 </td>
                 <td
                   class="numero align-middle"
@@ -258,24 +228,14 @@
                   <span
                     *ngIf="item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato) > 0"
                     class="negativo">
-                    {{ (item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato)) / (item.mediana_valor * item.qt_itens_contrato) | percent:'1.1' }}
+                    +{{ (item.vl_total_item_contrato - (item.mediana_valor * item.qt_itens_contrato)) / (item.mediana_valor * item.qt_itens_contrato) | percent:'1.1' }}
                   </span>
                 </td>
                 <td
                   class="numero align-middle"
                   *ngIf="radioGroupForm.value['showTotal']"
                   [title]="item.itensLicitacaoItensContrato.vl_unitario_estimado * item.qt_itens_contrato">
-                  <span *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado === 0">--</span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado < 0"
-                    class="positivo">
-                    {{ item.qt_itens_contrato * (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) | currency:'':'' }}
-                  </span>
-                  <span
-                    *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado > 0"
-                    class="negativo">
-                    +{{ item.qt_itens_contrato * (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado) | currency:'':'' }}
-                  </span>
+                  {{ item.qt_itens_contrato * item.itensLicitacaoItensContrato.vl_unitario_estimado | currency:'':'' }}
                 </td>
                 <td
                   class="numero align-middle"
@@ -290,7 +250,7 @@
                   <span
                     *ngIf="item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado > 0"
                     class="negativo">
-                    {{ (item.qt_itens_contrato * (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado)) / (item.itensLicitacaoItensContrato.vl_unitario_estimado * item.qt_itens_contrato) | percent:'1.1' }}
+                    +{{ (item.qt_itens_contrato * (item.vl_item_contrato - item.itensLicitacaoItensContrato.vl_unitario_estimado)) / (item.itensLicitacaoItensContrato.vl_unitario_estimado * item.qt_itens_contrato) | percent:'1.1' }}
                   </span>
                 </td>
               </tr>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -85,108 +85,61 @@
               <tr>
                 <th
                   scope="col"
-                  rowspan="2"
-                  class="text-left align-middle">
-                  Item
+                  class="text-left table-th-dividido-up align-middle">
+                Item
                 </th>
                 <th
                   scope="col"
-                  rowspan="2"
-                  class="table-th-monospace text-right"
+                  class="table-th-monospace table-th-dividido-up text-right"
                   *ngIf="!radioGroupForm.value['showTotal']">
                   Valor por
                   <br>
-                  unidade (R$)
+                  unidade
+                  <br>
+                  (R$)
                 </th>
                 <th
                   scope="col"
-                  colspan="2"
-                  class="table-th-monospace table-th-dividido text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
-                  vs
-                  estado
-                </th>
-                <th
-                  scope="col"
-                  colspan="2"
-                  class="table-th-monospace table-th-dividido text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
-                  vs
-                  estimado
-                </th>
-                <th
-                  scope="col"
-                  rowspan="2"
-                  class="table-th-monospace text-right"
+                  class="table-th-monospace table-th-dividido-up text-right"
                   *ngIf="radioGroupForm.value['showTotal']">
+                  Valor total
+                  <br>
+                  (R$)
+                </th>
+                <th
+                  scope="col"
+                  class="table-th-monospace table-th-dividido-up text-right">
+                  Valor médio
+                  <br>
+                  no estado
+                  <br>
+                  (R$)
+                </th>
+                <th
+                  scope="col"
+                  class="table-th-monospace table-th-percent table-th-dividido-up text-right">
+                  Contrato
+                  <br>
+                  vs estado
+                  <br>
+                  (%)
+                </th>
+                <th
+                  scope="col"
+                  class="table-th-monospace table-th-dividido-up text-right">
                   Valor
                   <br>
-                  total (R$)
-                </th>
-                <th
-                  scope="col"
-                  colspan="2"
-                  class="table-th-monospace table-th-dividido text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
-                  vs
-                  estado
-                </th>
-                <th
-                  scope="col"
-                  colspan="2"
-                  class="table-th-monospace table-th-dividido text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
-                  vs
                   estimado
-                </th>
-              </tr>
-              <tr>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
+                  <br>
                   (R$)
                 </th>
                 <th
                   scope="col"
-                  class="table-th-monospace table-th-percent table-th-dividido-up text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
-                  (%)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
-                  (R$)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-percent table-th-dividido-up text-right"
-                  *ngIf="!radioGroupForm.value['showTotal']">
-                  (%)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
-                  (R$)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up table-th-percent text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
-                  (%)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
-                  (R$)
-                </th>
-                <th
-                  scope="col"
-                  class="table-th-monospace table-th-dividido-up table-th-percent text-right"
-                  *ngIf="radioGroupForm.value['showTotal']">
+                  class="table-th-monospace table-th-percent table-th-dividido-up text-right">
+                  Pago vs
+                  <br>
+                  estimado
+                  <br>
                   (%)
                 </th>
               </tr>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.scss
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.scss
@@ -1,6 +1,7 @@
 .btn-item {
   white-space: nowrap;
 }
+
 .negativo {
   color: #b7472a;
 }
@@ -45,5 +46,5 @@
 }
 
 .table-th-percent {
-  width: 80px;
+  min-width: 80px;
 }


### PR DESCRIPTION
* Modifiquei os nomes das colunas e as métricas de diferença para valores absolutos
* Mudei a string de "Estimado vs Contratado" para "Contratado vs Estimado" para ficar consistente com a disposição dos itens na tabela (o valor contratado vem antes)
* Removi as cores das novas colunas com valores absolutos porque achei confuso deixá-las
* Adicionei um "+" antes de valores positivos nas colunas de variação percentual para representar aumento dos preços e ficar consistente com o "-" quando os preços são mais baratos

PS.: acabei também juntando o trabalho da task #277.