### PR TITLE
Adiciona links para o edital da licitação na página de detalhes

### DIFF
--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
@@ -69,23 +69,29 @@
           {{ licitacao?.descricao_objeto | initialcase }}
         </div>
       </div>
-      <div *ngIf="licitacao?.docsLicitacao.length" class="col-12">
-        <div class="dados-linha">
-          <strong>Editais</strong>
-          <app-tooltip-ajuda
-            [posicao]="'right'"
-            [descricao]="'Os editais foram informados pelo município ao TCE'"></app-tooltip-ajuda>
-        </div>
-        <div class="dados-linha mt-3">
-          <ul *ngFor="let doc of licitacao?.docsLicitacao">
-            <li>
-              <a target="_blank" rel="noopener noreferrer" href="{{doc?.arquivo_url_download}}">{{ doc?.nome_arquivo_documento }}</a>
-            </li>
-          </ul>
-        </div>
-      </div>
     </div>
 
+  </div>
+  <div
+    class="mb-4"
+    *ngIf="licitacao?.docsLicitacao.length">
+    <h4 class="titulo-sessao">
+      Editais
+      <app-tooltip-ajuda
+        [posicao]="'right'"
+        [descricao]="'Os editais foram informados pelo município ao TCE'"></app-tooltip-ajuda>
+    </h4>
+
+    <ul>
+      <li *ngFor="let doc of licitacao?.docsLicitacao">
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="{{doc?.arquivo_url_download}}">
+          {{ doc?.nome_arquivo_documento }}
+        </a>
+      </li>
+    </ul>
   </div>
   <app-timeline [timeline]="timeline"></app-timeline>
 </div>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
@@ -58,7 +58,7 @@
           {{ licitacao?.cd_tipo_modalidade}} - {{ licitacao?.tipo_modalidade_licitacao | initialcase }}
         </div>
       </div>
-      <div class="col-12">
+      <div class="col-12 mb-4">
         <div class="dados-linha">
           <strong>Objeto da licitação</strong>
           <app-tooltip-ajuda
@@ -67,6 +67,21 @@
         </div>
         <div class="dados-linha">
           {{ licitacao?.descricao_objeto | initialcase }}
+        </div>
+      </div>
+      <div *ngIf="licitacao?.docsLicitacao.length" class="col-12">
+        <div class="dados-linha">
+          <strong>Editais</strong>
+          <app-tooltip-ajuda
+            [posicao]="'right'"
+            [descricao]="'Os editais foram informados pelo município ao TCE'"></app-tooltip-ajuda>
+        </div>
+        <div class="dados-linha mt-3">
+          <ul *ngFor="let doc of licitacao?.docsLicitacao">
+            <li>
+              <a target="_blank" rel="noopener noreferrer" href="{{doc?.arquivo_url_download}}">{{ doc?.nome_arquivo_documento }}</a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.scss
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.scss
@@ -1,1 +1,3 @@
-
+li {
+    line-height: 0.75;
+}

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.scss
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.scss
@@ -1,3 +1,0 @@
-li {
-    line-height: 0.75;
-}

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/timeline/timeline.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/timeline/timeline.component.html
@@ -1,23 +1,27 @@
-<h4 class="titulo-sessao">Eventos</h4>
+<div *ngIf="timeline.length">
+  <h4 class="titulo-sessao">Eventos</h4>
 
-<div class="timeline mb-4">
+  <div class="timeline mb-4">
 
-  <div
-    class="timeline-event"
-    *ngFor="let evento of timeline">
-    <div class="timeline-event-title">
-      <div class="timeline-marker">
-        <span class="timeline-marker-icon"></span>
-      </div>
-      <div class="timeline-date">
-        <strong class="numero">{{ evento.key | date: "dd-MM-yyy" }}</strong>
-      </div>
-    </div>
     <div
-      class="timeline-content"
-      *ngFor="let tipo of evento.values">
-      <span>{{ novidadeService.getTextoResumo(tipo.value.novidade, tipo.value.total) }}</span>
+      class="timeline-event"
+      *ngFor="let evento of timeline">
+      <div class="timeline-event-title">
+        <div class="timeline-marker">
+          <span class="timeline-marker-icon"></span>
+        </div>
+        <div class="timeline-date">
+          <strong class="numero">{{ evento.key | date: "dd-MM-yyy" }}</strong>
+        </div>
+      </div>
+      <div
+        class="timeline-content"
+        *ngFor="let tipo of evento.values">
+        <span>
+          {{ novidadeService.getTextoResumo(tipo.value.novidade, tipo.value.total) }}
+        </span>
+      </div>
     </div>
-  </div>
 
+  </div>
 </div>

--- a/client/src/app/shared/models/documentoLicitacao.model.ts
+++ b/client/src/app/shared/models/documentoLicitacao.model.ts
@@ -1,0 +1,7 @@
+export interface DocumentoLicitacao {
+  arquivo_url_download: string;
+  cd_tipo_documento: string;
+  descricao_tipo_documento: string;
+  id_documento_licitacao: string;
+  nome_arquivo_documento: string;
+}

--- a/client/src/app/shared/models/licitacao.model.ts
+++ b/client/src/app/shared/models/licitacao.model.ts
@@ -1,4 +1,5 @@
 import { ContratoLicitacao } from './contratoLicitacao.model';
+import { DocumentoLicitacao } from './documentoLicitacao.model';
 
 export interface Licitacao {
   id_licitacao: number;
@@ -17,4 +18,5 @@ export interface Licitacao {
   descricao_objeto: string;
   merenda: boolean;
   contratosLicitacao: ContratoLicitacao[];
+  docsLicitacao: DocumentoLicitacao[];
 }

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -8,6 +8,7 @@ const itensLicitacaoModel = "./postgres/itensLicitacao.js";
 const contratoModel = "./postgres/contrato.js";
 const itensContratoModel = "./postgres/itensContrato.js"
 const fornecedorModel = "./postgres/fornecedor.js"
+const documentoLicitacaoModel = "./postgres/documentoLicitacao.js"
 
 if (!global.hasOwnProperty("models")) {
   const db = process.env.POSTGRESURI;
@@ -38,7 +39,8 @@ if (!global.hasOwnProperty("models")) {
     itensLicitacao: sequelize.import(itensLicitacaoModel),
     contrato: sequelize.import(contratoModel),
     itensContrato: sequelize.import(itensContratoModel),
-    fornecedor: sequelize.import(fornecedorModel)
+    fornecedor: sequelize.import(fornecedorModel),
+    documentoLicitacao: sequelize.import(documentoLicitacaoModel)
     //add your others models here
   };
 

--- a/server/models/postgres/documentoLicitacao.js
+++ b/server/models/postgres/documentoLicitacao.js
@@ -1,0 +1,43 @@
+module.exports = (sequelize, type) => {
+  documentoLicitacao = sequelize.define(
+    "documento_licitacao",
+    {
+      id_documento_licitacao: {
+        type: type.STRING,
+        primaryKey: true
+      },
+      id_licitacao: type.STRING,
+      id_orgao: type.INTEGER,
+      nr_licitacao: type.STRING,
+      ano_licitacao: type.INTEGER,
+      cd_tipo_modalidade: type.STRING,
+      cd_tipo_documento: type.STRING,
+      nome_arquivo_documento: type.STRING,
+      cd_tipo_fase: type.STRING,
+      id_evento_licitacao: type.STRING,
+      tp_documento: type.STRING,
+      nr_documento: type.DATE,
+      arquivo_timestamp: type.STRING,
+      arquivo_url_download: type.STRING,
+      descricao_tipo_documento: type.STRING
+    },
+    {
+      freezeTableName: true,
+      timestamps: false
+    }
+  );
+
+  documentoLicitacao.associate = function (models) {
+    documentoLicitacao.belongsTo(models.orgao, {
+      foreignKey: "id_orgao",
+      sourceKey: "id_orgao",
+      as: "documentosLicitacaoOrgao"
+    });
+    documentoLicitacao.belongsTo(models.licitacao, {
+      foreignKey: "id_licitacao",
+      sourceKey: "id_licitacao",
+      as: "docsLicitacao"
+    });
+  };
+  return documentoLicitacao;
+};

--- a/server/models/postgres/licitacao.js
+++ b/server/models/postgres/licitacao.js
@@ -56,6 +56,11 @@ module.exports = (sequelize, type) => {
       sourceKey: "id_licitacao",
       as: "licitacaoItensContrato"
     });
+    licitacao.hasMany(models.documentoLicitacao, {
+      foreignKey: "id_licitacao",
+      sourceKey: "id_licitacao",
+      as: "docsLicitacao"
+    });
   };
   return licitacao;
 };

--- a/server/models/postgres/orgao.js
+++ b/server/models/postgres/orgao.js
@@ -41,6 +41,11 @@ module.exports = (sequelize, type) => {
       sourceKey: "id_orgao",
       as: "itensContratoOrgao"
     });
+    orgao.hasMany(models.documentoLicitacao, {
+      foreignKey: "id_orgao",
+      sourceKey: "id_orgao",
+      as: "documentosLicitacaoOrgao"
+    });
   };
   return orgao;
 };

--- a/server/routes/api/licitacoes.js
+++ b/server/routes/api/licitacoes.js
@@ -9,6 +9,7 @@ const models = require("../../models/index");
 const Licitacao = models.licitacao;
 const Contrato = models.contrato;
 const Orgao = models.orgao;
+const DocumentoLicitacao = models.documentoLicitacao;
 
 const BAD_REQUEST = 400;
 const SUCCESS = 200;
@@ -73,6 +74,15 @@ router.get("/:id", (req, res) => {
         model: Contrato,
         attributes: ["vl_contrato"],
         as: "contratosLicitacao"
+      },
+      {
+        model: DocumentoLicitacao,
+        attributes: ["id_documento_licitacao", "descricao_tipo_documento", "cd_tipo_documento", "nome_arquivo_documento", "arquivo_url_download"],
+        as: "docsLicitacao",
+        where: {
+          cd_tipo_documento: "EDI"
+        },
+        required: false
       }
     ],
     where: {


### PR DESCRIPTION
## Mudanças
- Adiciona links para o edital da licitação na página de detalhes
- Adiciona endpoint e model para documentos de licitações

## Flags
- Depende da versão de dados gerada pelo ta-na-mesa-dados do PR https://github.com/analytics-ufcg/ta-na-mesa-dados/pull/74
Basta executar o processamento inicial (`make process-data anos=2018,2019,2020`)