### PR TITLE
 Corrige exibição da quantidade de itens na tela detalhada de um item

### DIFF
--- a/client/src/app/shared/components/descricao-item/descricao-item.component.html
+++ b/client/src/app/shared/components/descricao-item/descricao-item.component.html
@@ -29,6 +29,6 @@
   </button>
   <span
     class="text-muted">
-    ({{ item.qt_itens_contrato }} {{ item.itensLicitacaoItensContrato.sg_unidade_medida | lowercase }})
+    ({{ item.qt_itens_contrato }} {{ item.sg_unidade_medida | lowercase }})
   </span>
 </div>

--- a/client/src/app/shared/components/descricao-item/descricao-item.component.html
+++ b/client/src/app/shared/components/descricao-item/descricao-item.component.html
@@ -28,7 +28,6 @@
     ...
   </button>
   <span
-    *ngIf="comUnidade"
     class="text-muted">
     ({{ item.qt_itens_contrato }} {{ item.sg_unidade_medida | lowercase }})
   </span>

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -72,12 +72,13 @@ router.post("/similares", (req, res) => {
   dataFinal = dataFinal.toJSON().slice(0, 10);
     
   let query = `SELECT ano_licitacao, id_item_contrato, id_contrato, nr_contrato, id_licitacao, vl_item_contrato, \
-                      vl_total_item_contrato, ds_item, dt_inicio_vigencia, nome_municipio, \
+                      vl_total_item_contrato, ds_item, dt_inicio_vigencia, qt_itens_contrato, nome_municipio, \
                       ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) as rel, \ 
                       sg_unidade_medida \
                       FROM item_search WHERE item_search.document @@ to_tsquery('portuguese', '${termo}') AND \
                       dt_inicio_vigencia >= '${dataInicial}' AND dt_inicio_vigencia <= '${dataFinal}'\
                       AND sg_unidade_medida = '${unidade}'\
+                      AND vl_item_contrato > 0 \
                       AND ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) >= 0.65\
                       ORDER BY ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) DESC, id_item_contrato ASC \
                       LIMIT 21;`


### PR DESCRIPTION
## Mudanças
- Corrige exibição da quantidade de itens na tela detalhada de um item
- Retorna apenas itens com valor superior a 0

## Flags
- Depende da versão dos dados: https://github.com/analytics-ufcg/ta-na-mesa-dados/pull/75
- Depende da revisão e aprovação do PR https://github.com/analytics-ufcg/ta-na-mesa/pull/139