### PR TITLE
Muda status da licitação para com/sem contratos e mais

### DIFF
--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -253,7 +253,7 @@
               <td
                 class="numero align-middle"
                 [title]="item.mediana_valor"
-                [style.background-color]="item?.itensSemelhantes?.length > 3 ? defineCorFundo(item.percentual_vs_estado) : 'white'"
+                [style.background-color]="item?.itensSemelhantes?.length > 1 ? defineCorFundo(item.percentual_vs_estado) : 'white'"
                 [style.color]="defineCor(item.percentual_vs_estado)">
                 <div
                   class="pr-3"

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -25,7 +25,7 @@
           <strong>Fornecedor</strong>
         </div>
         <div class="dados-linha">
-          {{ contrato?.contratoFornecedor.nm_pessoa }}
+          {{ contrato?.nm_fornecedor }}
           <span class="text-muted">
             ({{ contrato?.nr_documento_contratado | formatCpfCnpj }})
           </span>

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -8,7 +8,6 @@
     [exibirVoltar]="true"></app-barra-titulo>
 
   <div class="container">
-    <app-spinner *ngIf="loading$ | async"></app-spinner>
     <div class="row mt-4">
       <div class="col-sm-12 col-md-3 mb-4">
         <div class="dados-linha">
@@ -82,7 +81,11 @@
       </div>
     </div>
 
-    <div class="table-wrapper">
+    <app-spinner *ngIf="loading$ | async"></app-spinner>
+
+    <div
+      *ngIf="(loading$ | async) === false"
+      class="table-wrapper">
       <div class="table-responsive">
         <table class="table table-sm">
           <thead>

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -112,13 +112,19 @@
             <tr>
               <th
                 scope="col"
-                class="text-left align-middle">
-                Item
+                class="text-left table-th-dividido-up align-middle"
+                ordenavel="ds_item"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
+                Produto
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right"
-                *ngIf="!radioGroupForm.value['showTotal']">
+                class="table-th-monospace table-th-dividido-up text-right"
+                *ngIf="!radioGroupForm.value['showTotal']"
+                ordenavel="vl_item_contrato"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 <span class="nowrap">Valor por</span>
                 <br>
                 unidade
@@ -127,15 +133,21 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right"
-                *ngIf="radioGroupForm.value['showTotal']">
+                class="table-th-monospace table-th-dividido-up text-right"
+                *ngIf="radioGroupForm.value['showTotal']"
+                ordenavel="vl_total_item_contrato"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 <span class="nowrap">Valor total</span>
                 <br>
                 (R$)
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right">
+                class="table-th-monospace table-th-dividido-up text-right"
+                ordenavel="mediana_valor"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Mediana
                 <br>
                 <span class="nowrap">no estado</span>
@@ -145,7 +157,10 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right">
+                class="table-th-monospace table-th-dividido-up text-right"
+                ordenavel="percentual_vs_estado"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Diferença
                 <br>
                 <span class="nowrap">com estado</span>
@@ -155,7 +170,10 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right">
+                class="table-th-monospace table-th-dividido-up text-right"
+                ordenavel="vl_unitario_estimado"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Valor
                 <br>
                 estimado
@@ -165,7 +183,10 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace text-right">
+                class="table-th-monospace table-th-dividido-up text-right"
+                ordenavel="percentual_vs_estimado"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Diferença
                 <br>
                 <span class="nowrap">com estimado</span>
@@ -179,7 +200,7 @@
           </thead>
           <tbody>
             <tr
-              *ngFor="let item of (itensContrato$ | async); index as i"
+              *ngFor="let item of listaService.dadosProcessados$ | async; index as i"
               class="table-item">
               <td class="align-middle descricao">
                 <app-descricao-item

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -112,7 +112,7 @@
             <tr>
               <th
                 scope="col"
-                class="text-left table-th-dividido-up align-middle"
+                class="text-left align-middle"
                 ordenavel="ds_item"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
@@ -120,7 +120,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 *ngIf="!radioGroupForm.value['showTotal']"
                 ordenavel="vl_item_contrato"
                 (ordenar)="onOrdenar($event)"
@@ -133,7 +133,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 *ngIf="radioGroupForm.value['showTotal']"
                 ordenavel="vl_total_item_contrato"
                 (ordenar)="onOrdenar($event)"
@@ -144,7 +144,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 ordenavel="mediana_valor"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
@@ -157,7 +157,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 ordenavel="percentual_vs_estado"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
@@ -170,7 +170,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 ordenavel="vl_unitario_estimado"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
@@ -183,7 +183,7 @@
               </th>
               <th
                 scope="col"
-                class="table-th-monospace table-th-dividido-up text-right"
+                class="table-th-monospace text-right"
                 ordenavel="percentual_vs_estimado"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
@@ -205,7 +205,7 @@
               <td class="align-middle descricao">
                 <app-descricao-item
                   [item]="item"
-                  [temLink]="item.itensSemelhantes?.length > 3"></app-descricao-item>
+                  [temLink]="item?.itensSemelhantes?.length > 3"></app-descricao-item>
               </td>
               <td
                 class="numero align-middle"

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -8,7 +8,7 @@
     [exibirVoltar]="true"></app-barra-titulo>
 
   <div class="container">
-    <app-spinner *ngIf="isLoading"></app-spinner>
+    <app-spinner *ngIf="loading$ | async"></app-spinner>
     <div class="row mt-4">
       <div class="col-sm-12 col-md-3 mb-4">
         <div class="dados-linha">
@@ -25,7 +25,7 @@
           <strong>Fornecedor</strong>
         </div>
         <div class="dados-linha">
-          {{ contrato?.nm_fornecedor }}
+          {{ contrato?.contratoFornecedor.nm_pessoa }}
           <span class="text-muted">
             ({{ contrato?.nr_documento_contratado | formatCpfCnpj }})
           </span>
@@ -179,7 +179,7 @@
           </thead>
           <tbody>
             <tr
-              *ngFor="let item of contrato?.itensContrato; index as i"
+              *ngFor="let item of (itensContrato$ | async); index as i"
               class="table-item">
               <td class="align-middle descricao">
                 <app-descricao-item
@@ -245,18 +245,18 @@
               <td
                 class="numero align-middle"
                 *ngIf="!radioGroupForm.value['showTotal']"
-                [title]="item.itensLicitacaoItensContrato.vl_unitario_estimado">
-                {{ item.itensLicitacaoItensContrato.vl_unitario_estimado | currency:'':'' }}
+                [title]="item.vl_unitario_estimado">
+                {{ item.vl_unitario_estimado | currency:'':'' }}
               </td>
               <td
                 class="numero align-middle"
                 *ngIf="radioGroupForm.value['showTotal']"
-                [title]="item.itensLicitacaoItensContrato.vl_unitario_estimado * item.qt_itens_contrato">
-                {{ item.qt_itens_contrato * item.itensLicitacaoItensContrato.vl_unitario_estimado | currency:'':'' }}
+                [title]="item.vl_unitario_estimado * item.qt_itens_contrato">
+                {{ item.qt_itens_contrato * item.vl_unitario_estimado | currency:'':'' }}
               </td>
               <td
                 class="numero align-middle"
-                [title]="item.itensLicitacaoItensContrato.vl_unitario_estimado"
+                [title]="item.vl_unitario_estimado"
                 [style.background-color]="defineCorFundo(item.percentual_vs_estimado)"
                 [style.color]="defineCor(item.percentual_vs_estimado)">
                 <span *ngIf="item.percentual_vs_estimado > 0">+</span>{{ item.percentual_vs_estimado | percent:'1.1' }}

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -205,7 +205,7 @@
               <td class="align-middle descricao">
                 <app-descricao-item
                   [item]="item"
-                  [temLink]="item?.itensSemelhantes?.length > 3"></app-descricao-item>
+                  [temLink]="item?.itensSemelhantes?.length > 1"></app-descricao-item>
               </td>
               <td
                 class="numero align-middle"
@@ -223,10 +223,10 @@
                 [title]="item.mediana_valor">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 3; else mostraMedianaEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 1; else mostraMedianaEstado">
                   <app-tooltip-ajuda
                   [tipo]="'alerta'"
-                  [descricao]="'Este valor não pôde ser calculado pois existem poucos produtos semelhantes em nossa base de dados.'"></app-tooltip-ajuda>
+                  [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                 </div>
                 <ng-template #mostraMedianaEstado>
                   {{ item.mediana_valor | currency:'':'' }}
@@ -238,10 +238,10 @@
                 [title]="item.mediana_valor * item.qt_itens_contrato">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 3; else mostraMedianaTotalEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 1; else mostraMedianaTotalEstado">
                   <app-tooltip-ajuda
                   [tipo]="'alerta'"
-                  [descricao]="'Este valor não pôde ser calculado pois existem poucos produtos semelhantes em nossa base de dados.'"></app-tooltip-ajuda>
+                  [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                 </div>
                 <ng-template #mostraMedianaTotalEstado>
                   {{ item.mediana_valor * item.qt_itens_contrato | currency:'':'' }}
@@ -254,10 +254,10 @@
                 [style.color]="defineCor(item.percentual_vs_estado)">
                 <div
                   class="pr-3"
-                  *ngIf="item?.itensSemelhantes?.length <= 3; else mostraPercentualEstado">
+                  *ngIf="item?.itensSemelhantes?.length <= 1; else mostraPercentualEstado">
                   <app-tooltip-ajuda
                   [tipo]="'alerta'"
-                  [descricao]="'Este valor não pôde ser calculado pois existem poucos produtos semelhantes em nossa base de dados.'"></app-tooltip-ajuda>
+                  [descricao]="'Não existem produtos no estado com descrição e quantidade semelhantes para comparação.'"></app-tooltip-ajuda>
                 </div>
                 <ng-template #mostraPercentualEstado>
                   <span *ngIf="item.percentual_vs_estado > 0">+</span>{{ item.percentual_vs_estado | percent:'1.1' }}

--- a/client/src/app/contratos/info-contrato/info-contrato.component.html
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.html
@@ -205,7 +205,7 @@
               <td class="align-middle descricao">
                 <app-descricao-item
                   [item]="item"
-                  [temLink]="item?.itensSemelhantes?.length > 3"></app-descricao-item>
+                  [temLink]="item.itensSemelhantes?.length > 3"></app-descricao-item>
               </td>
               <td
                 class="numero align-middle"

--- a/client/src/app/contratos/info-contrato/info-contrato.component.scss
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.scss
@@ -32,11 +32,11 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e911';
+  content: '\e90d';
 }
 
 th[ordenavel].desc:before {
-  content: '\e90d';
+  content: '\e911';
 }
 
 

--- a/client/src/app/contratos/info-contrato/info-contrato.component.scss
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.scss
@@ -32,11 +32,11 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e90d';
+  content: '\e911';
 }
 
 th[ordenavel].desc:before {
-  content: '\e911';
+  content: '\e90d';
 }
 
 

--- a/client/src/app/contratos/info-contrato/info-contrato.component.scss
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.scss
@@ -39,7 +39,6 @@ th[ordenavel].desc:before {
   content: '\e911';
 }
 
-
 .contrato-corpo {
   background-color: #ffffff;
   border-radius: 5px;

--- a/client/src/app/contratos/info-contrato/info-contrato.component.scss
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.scss
@@ -1,3 +1,51 @@
+@font-face {
+  font-family: 'icomoon';
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4');
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4#iefix') format('embedded-opentype'),
+    url('../../../assets/fonts/icomoon.ttf?fw8tb4') format('truetype'),
+    url('../../../assets/fonts/icomoon.woff?fw8tb4') format('woff'),
+    url('../../../assets/fonts/icomoon.svg?fw8tb4#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
+th[ordenavel] {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+th[ordenavel].asc:before, th[ordenavel].desc:before {
+  font-family: 'icomoon'!important;
+  display: inline;
+
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+th[ordenavel].asc:before {
+  content: '\e90d';
+}
+
+th[ordenavel].desc:before {
+  content: '\e911';
+}
+
+
+.contrato-corpo {
+  background-color: #ffffff;
+  border-radius: 5px;
+  padding: 5px;
+}
+
 .btn-item {
   white-space: nowrap;
 }

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -5,7 +5,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
 import * as d3 from 'd3-scale';
 
 import { forkJoin, BehaviorSubject, from } from 'rxjs';
-import { take, map, concatMap, mergeMap, reduce } from 'rxjs/operators';
+import { take, map, concatMap, mergeMap, reduce, tap } from 'rxjs/operators';
 
 import { ContratoLicitacao } from 'src/app/shared/models/contratoLicitacao.model';
 import { ContratoService } from 'src/app/shared/services/contrato.service';
@@ -73,7 +73,6 @@ export class InfoContratoComponent implements OnInit {
       this.contrato.valor_estimado = itensContrato.reduce((sum, item) => {
         return sum + (item.vl_unitario_estimado * item.qt_itens_contrato);
       }, 0);
-      this.loading$.next(false);
     });
   }
 
@@ -102,7 +101,8 @@ export class InfoContratoComponent implements OnInit {
               }),
               reduce((acc: Array<any>, element: any) => [...acc, element], [])
             );
-        })
+        }),
+        tap(() => this.loading$.next(false))
       );
   }
 

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -86,11 +86,10 @@ export class InfoContratoComponent implements OnInit {
           itensContrato.map(item => {
             item.ds_item_resumido = this.resumirPipe.transform(item.ds_item);
             const termos = this.termosPipe.transform(item.ds_item);
-            this.itensService.getMediaItensSemelhantes(termos, item.dt_inicio_vigencia)
-              .then(res => {
-                item.mediana_valor = res.mediana;
-                item.itensSemelhantes = res.itensOrdenados;
-                item.percentual_vs_estado = (item.vl_item_contrato - res.mediana) / res.mediana;
+            this.itensService.getMediaItensSemelhantes(item, termos)
+              .subscribe(itemComMediana => {
+                item = itemComMediana;
+                item.percentual_vs_estado = (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor;
                 item.percentual_vs_estimado = (item.vl_item_contrato - item.vl_unitario_estimado)
                   / item.vl_unitario_estimado;
               });

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -1,14 +1,13 @@
-import { Component, OnInit, OnDestroy, ViewChildren, QueryList } from '@angular/core';
+import { Component, OnInit, ViewChildren, QueryList } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FormBuilder, FormGroup } from '@angular/forms';
 
 import * as d3 from 'd3-scale';
 
-import { Subject, forkJoin, BehaviorSubject, Observable } from 'rxjs';
+import { forkJoin, BehaviorSubject } from 'rxjs';
 import { take, map } from 'rxjs/operators';
 
 import { ContratoLicitacao } from 'src/app/shared/models/contratoLicitacao.model';
-import { ItensContrato } from 'src/app/shared/models/itensContrato.model';
 import { ContratoService } from 'src/app/shared/services/contrato.service';
 import { ItensService } from 'src/app/shared/services/itens.service';
 import { ResumirTextoPipe } from 'src/app/shared/pipes/resumir-texto.pipe';
@@ -29,16 +28,13 @@ import { DecimalPipe } from '@angular/common';
     DecimalPipe
   ]
 })
-export class InfoContratoComponent implements OnInit, OnDestroy {
-
-  private unsubscribe = new Subject();
+export class InfoContratoComponent implements OnInit {
 
   public loading$ = new BehaviorSubject<boolean>(true);
-
-  @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
-
   public contrato: ContratoLicitacao;
   public radioGroupForm: FormGroup;
+
+  @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
   constructor(
     private activatedroute: ActivatedRoute,
@@ -128,10 +124,4 @@ export class InfoContratoComponent implements OnInit, OnDestroy {
   defineCor(valor: number): string {
     return (valor >= 0.7 || valor <= -0.7) ? 'white' : 'black';
   }
-
-  ngOnDestroy() {
-    this.unsubscribe.next();
-    this.unsubscribe.complete();
-  }
-
 }

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -34,12 +34,10 @@ export class InfoContratoComponent implements OnInit, OnDestroy {
   private unsubscribe = new Subject();
 
   public loading$ = new BehaviorSubject<boolean>(true);
-  public itensContrato$: Observable<any[]>;
 
   @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
   public contrato: ContratoLicitacao;
-  public itemSelecionado: ItensContrato;
   public radioGroupForm: FormGroup;
 
   constructor(

--- a/client/src/app/contratos/info-contrato/info-contrato.component.ts
+++ b/client/src/app/contratos/info-contrato/info-contrato.component.ts
@@ -91,8 +91,14 @@ export class InfoContratoComponent implements OnInit {
                 .pipe(
                   map(itemComMediana => {
                     item = itemComMediana;
-                    item.percentual_vs_estado = (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor;
-                    item.percentual_vs_estado = Math.round((item.percentual_vs_estado + Number.EPSILON) * 1000) / 1000;
+                    // Se não houver itens similares, o valor da mediana será NaN
+                    // Este trecho atribui um valor bem pequeno para que todos os itens sem semelhantes fiquem ordenados primeiro
+                    if (isNaN(item.mediana_valor) || (item.itensSemelhantes && item.itensSemelhantes.length === 1)) {
+                      item.mediana_valor = -1; // Não existem itens com preços negativos
+                      item.percentual_vs_estado = -1000000000; // Valor pequeno e improvável de ter algum item com preço menor
+                    } else {
+                      item.percentual_vs_estado = (item.vl_item_contrato - item.mediana_valor) / item.mediana_valor;
+                    }
                     item.percentual_vs_estimado = (item.vl_item_contrato - item.vl_unitario_estimado)
                       / item.vl_unitario_estimado;
                     return item;

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -11,6 +11,7 @@
         <app-descricao-item
           [item]="item"
           [temLink]="false"
+          [comUnidade]="false"
           [itemResumido]="false"></app-descricao-item>
       </div>
       <div class="col-lg-5">
@@ -108,7 +109,8 @@
               <td class="align-middle">
                 <app-descricao-item
                     [item]="itemSemelhante"
-                    [temLink]="false"></app-descricao-item>
+                    [temLink]="false"
+                    [comUnidade]="false"></app-descricao-item>
               </td>
               <td class="align-middle nowrap">{{ itemSemelhante.nome_municipio | titlecase }}</td>
               <td class="align-middle text-right">

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -67,16 +67,36 @@
         <table class="table table-sm table-hover">
           <thead>
             <tr>
-              <th scope="col" class="align-middle table-th-dividido-up">
+              <th
+                scope="col"
+                class="align-middle table-th-dividido-up"
+                ordenavel="ds_item"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Produto
               </th>
-              <th scope="col" class="table-th-monospace table-th-dividido-up">
+              <th
+                scope="col"
+                class="table-th-monospace table-th-dividido-up"
+                ordenavel="nome_municipio"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Município
               </th>
-              <th scope="col" class="table-th-monospace text-right table-th-dividido-up">
+              <th
+                scope="col"
+                class="table-th-monospace text-right table-th-dividido-up"
+                ordenavel="ano_licitacao"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Contrato
               </th>
-              <th scope="col" class="table-th-monospace text-right table-th-dividido-up">
+              <th
+                scope="col"
+                class="table-th-monospace text-right table-th-dividido-up"
+                ordenavel="vl_item_contrato"
+                (ordenar)="onOrdenar($event)"
+                appOrdenavel>
                 Valor por
                 <br />
                 unidade (R$)
@@ -84,7 +104,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr *ngFor="let itemSemelhante of item.itensSemelhantes; index as i" class>
+            <tr *ngFor="let itemSemelhante of listaService.dadosProcessados$ | async; index as i" class>
               <td class="align-middle">
                 <app-descricao-item
                     [item]="itemSemelhante"

--- a/client/src/app/itens/info-item/info-item.component.scss
+++ b/client/src/app/itens/info-item/info-item.component.scss
@@ -32,11 +32,11 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e911';
+  content: '\e90d';
 }
 
 th[ordenavel].desc:before {
-  content: '\e90d';
+  content: '\e911';
 }
 
 .item-destaque-wrapper {

--- a/client/src/app/itens/info-item/info-item.component.scss
+++ b/client/src/app/itens/info-item/info-item.component.scss
@@ -1,3 +1,44 @@
+@font-face {
+  font-family: 'icomoon';
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4');
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4#iefix') format('embedded-opentype'),
+    url('../../../assets/fonts/icomoon.ttf?fw8tb4') format('truetype'),
+    url('../../../assets/fonts/icomoon.woff?fw8tb4') format('woff'),
+    url('../../../assets/fonts/icomoon.svg?fw8tb4#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
+th[ordenavel] {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+th[ordenavel].asc:before, th[ordenavel].desc:before {
+  font-family: 'icomoon'!important;
+  display: inline;
+
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+th[ordenavel].asc:before {
+  content: '\e911';
+}
+
+th[ordenavel].desc:before {
+  content: '\e90d';
+}
+
 .item-destaque-wrapper {
   position: sticky;
   top: 60px;

--- a/client/src/app/itens/info-item/info-item.component.ts
+++ b/client/src/app/itens/info-item/info-item.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, ViewChildren, QueryList } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
-import { Subject } from 'rxjs';
-import { take, takeUntil, map, concatMap } from 'rxjs/operators';
+import { take, map, concatMap } from 'rxjs/operators';
 
 import * as d3 from 'd3-scale';
 
@@ -83,19 +82,6 @@ export class InfoItemComponent implements OnInit {
         })
       );
   }
-
-  // item.itensSemelhantes = res.itensOrdenados
-  //             .filter(itemSemelhante => itemSemelhante.id_item_contrato !== item.id_item_contrato);
-  //           item.itensSemelhantes.map(itemSemelhante => {
-  //             itemSemelhante.ds_item_resumido = this.resumirPipe.transform(itemSemelhante.ds_item);
-  //             if (itemSemelhante.vl_item_contrato > 0) {
-  //               itemSemelhante.percentual_vs_semelhante = (item.vl_item_contrato - itemSemelhante.vl_item_contrato)
-  //                 / itemSemelhante.vl_item_contrato;
-  //             } else {
-  //               itemSemelhante.percentual_vs_semelhante = 0;
-  //             }
-  //           });
-  //           this.item = item;
 
   onOrdenar({coluna, direcao}: EventoOrd) {
     // Reseta outros cabeçalhos

--- a/client/src/app/itens/info-item/info-item.component.ts
+++ b/client/src/app/itens/info-item/info-item.component.ts
@@ -69,7 +69,7 @@ export class InfoItemComponent implements OnInit {
         concatMap(item => {
           const termos = this.termosPipe.transform(item.ds_item);
           return this.itensService
-            .getItensSimilares(termos, item.dt_inicio_vigencia)
+            .getItensSimilares(item, termos)
             .pipe(
               // filtra dos semelhantes o item atual
               map(itensSemelhantes => itensSemelhantes.filter(itemSemelhante => itemSemelhante.id_item_contrato !== item.id_item_contrato))

--- a/client/src/app/itens/info-item/info-item.component.ts
+++ b/client/src/app/itens/info-item/info-item.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChildren, QueryList } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { Subject } from 'rxjs';
-import { take, takeUntil, map } from 'rxjs/operators';
+import { take, takeUntil, map, concatMap } from 'rxjs/operators';
 
 import * as d3 from 'd3-scale';
 
@@ -10,6 +10,10 @@ import { ItensContrato } from 'src/app/shared/models/itensContrato.model';
 import { ItensService } from 'src/app/shared/services/itens.service';
 import { TermosImportantesPipe } from 'src/app/shared/pipes/termos-importantes.pipe';
 import { ResumirTextoPipe } from 'src/app/shared/pipes/resumir-texto.pipe';
+import { EventoOrd } from 'src/app/shared/models/lista.model';
+import { OrdenavelDirective } from 'src/app/shared/directives/ordenavel.directive';
+import { ListaItensService } from 'src/app/shared/services/lista.service';
+import { DecimalPipe } from '@angular/common';
 
 @Component({
   selector: 'app-info-item',
@@ -17,49 +21,94 @@ import { ResumirTextoPipe } from 'src/app/shared/pipes/resumir-texto.pipe';
   styleUrls: ['./info-item.component.scss'],
   providers: [
     TermosImportantesPipe,
-    ResumirTextoPipe
+    ResumirTextoPipe,
+    ListaItensService,
+    DecimalPipe
   ]
 })
 export class InfoItemComponent implements OnInit {
 
-  private unsubscribe = new Subject();
-
   public item: ItensContrato;
+
+  @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
   constructor(
     private activatedroute: ActivatedRoute,
-    private itensService: ItensService,
     private termosPipe: TermosImportantesPipe,
-    private resumirPipe: ResumirTextoPipe
+    private resumirPipe: ResumirTextoPipe,
+    private itensService: ItensService,
+    public listaService: ListaItensService
   ) { }
 
   ngOnInit() {
     this.activatedroute.params.pipe(take(1)).subscribe(params => {
       this.getItemByID(params.id);
+      this.getItensSemelhantesByID(params.id);
     });
   }
+
   getItemByID(id: any) {
-    this.itensService.get(id)
-      .pipe(takeUntil(this.unsubscribe))
+    this.itensService
+      .get(id)
+      .pipe(
+        concatMap(item => {
+          const termos = this.termosPipe.transform(item.ds_item);
+          return this.itensService
+            .getMediaItensSemelhantes(item, termos);
+        })
+      )
       .subscribe(item => {
         item.ds_item_resumido = this.resumirPipe.transform(item.ds_item);
-        const termos = this.termosPipe.transform(item.ds_item);
-        this.itensService.getMediaItensSemelhantes(termos, item.dt_inicio_vigencia, item.sg_unidade_medida)
-          .then(res => {
-            item.mediana_valor = res.mediana;
-            item.itensSemelhantes = res.itensOrdenados.filter(itemSemelhante => itemSemelhante.id_item_contrato !== item.id_item_contrato);
-            item.itensSemelhantes.map(itemSemelhante => {
-              itemSemelhante.ds_item_resumido = this.resumirPipe.transform(itemSemelhante.ds_item);
-              if (itemSemelhante.vl_item_contrato > 0) {
-                itemSemelhante.percentual_vs_semelhante = (item.vl_item_contrato - itemSemelhante.vl_item_contrato)
-                  / itemSemelhante.vl_item_contrato;
-              } else {
-                itemSemelhante.percentual_vs_semelhante = 0;
-              }
-            });
-            this.item = item;
-          });
+        this.item = item;
       });
+  }
+
+  getItensSemelhantesByID(id: any) {
+    this.listaService.dados$ = this.itensService
+      .get(id)
+      .pipe(
+        concatMap(item => {
+          const termos = this.termosPipe.transform(item.ds_item);
+          return this.itensService
+            .getItensSimilares(termos, item.dt_inicio_vigencia)
+            .pipe(
+              // filtra dos semelhantes o item atual
+              map(itensSemelhantes => itensSemelhantes.filter(itemSemelhante => itemSemelhante.id_item_contrato !== item.id_item_contrato))
+            );
+        }),
+        map(itens => {
+          // cria resumo da descrição
+          itens.map(item => item.ds_item_resumido = this.resumirPipe.transform(item.ds_item));
+          return itens;
+        })
+      );
+  }
+
+  // item.itensSemelhantes = res.itensOrdenados
+  //             .filter(itemSemelhante => itemSemelhante.id_item_contrato !== item.id_item_contrato);
+  //           item.itensSemelhantes.map(itemSemelhante => {
+  //             itemSemelhante.ds_item_resumido = this.resumirPipe.transform(itemSemelhante.ds_item);
+  //             if (itemSemelhante.vl_item_contrato > 0) {
+  //               itemSemelhante.percentual_vs_semelhante = (item.vl_item_contrato - itemSemelhante.vl_item_contrato)
+  //                 / itemSemelhante.vl_item_contrato;
+  //             } else {
+  //               itemSemelhante.percentual_vs_semelhante = 0;
+  //             }
+  //           });
+  //           this.item = item;
+
+  onOrdenar({coluna, direcao}: EventoOrd) {
+    // Reseta outros cabeçalhos
+    this.cabecalhos.forEach(cab => {
+      if (cab.ordenavel !== coluna) {
+        cab.direcao = '';
+        cab.ordAsc = false;
+        cab.ordDesc = false;
+      }
+    });
+
+    this.listaService.colunaOrd = coluna;
+    this.listaService.direcaoOrd = direcao;
   }
 
   defineCorFundo(valor: number): string {

--- a/client/src/app/itens/info-item/info-item.component.ts
+++ b/client/src/app/itens/info-item/info-item.component.ts
@@ -78,6 +78,8 @@ export class InfoItemComponent implements OnInit {
         map(itens => {
           // cria resumo da descrição
           itens.map(item => item.ds_item_resumido = this.resumirPipe.transform(item.ds_item));
+          // itens ordenados pelo preço
+          itens.sort((i1, i2) => i1.vl_item_contrato - i2.vl_item_contrato);
           return itens;
         })
       );

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.html
@@ -1,10 +1,9 @@
 <h4 class="my-4 d-block d-sm-none">Contratos</h4>
 <div>
-  <p [hidden]="contratoLicitacao?.length > 0 || isLoading">
+  <p *ngIf="((contratosLicitacao$ | async)?.length === 0)">
     Ainda não há contratos para essa licitação.
   </p>
 
-  <app-spinner *ngIf="isLoading"></app-spinner>
-
-  <app-lista-contratos [contratos]="contratoLicitacao" [isLoading]="isLoading"></app-lista-contratos>
+  <app-lista-contratos
+    [contratos$]="contratosLicitacao$"></app-lista-contratos>
 </div>

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-contratos/licitacoes-detalhar-contratos.component.ts
@@ -1,17 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { FormBuilder, FormGroup } from '@angular/forms';
 
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs';
-import { take, map } from 'rxjs/operators';
+import { take, concatMap } from 'rxjs/operators';
 
 import { ContratoLicitacao } from 'src/app/shared/models/contratoLicitacao.model';
 import { LicitacaoService } from 'src/app/shared/services/licitacao.service';
-import { ItensContrato } from 'src/app/shared/models/itensContrato.model';
-import { ItensService } from 'src/app/shared/services/itens.service';
-
-import * as d3 from 'd3-scale';
 
 @Component({
   selector: 'app-licitacoes-detalhar-contratos',
@@ -22,72 +16,16 @@ export class LicitacoesDetalharContratosComponent implements OnInit {
 
   public contratosLicitacao$: Observable<ContratoLicitacao[]>;
 
-  public itemSelecionado: ItensContrato;
-  public activeIds: string[] = [];
-  public radioGroupForm: FormGroup;
-  public showTotal = false;
-
   constructor(
     private activatedroute: ActivatedRoute,
-    private formBuilder: FormBuilder,
-    private modalService: NgbModal,
-    private licitacaoService: LicitacaoService,
-    private itensService: ItensService) { }
+    private licitacaoService: LicitacaoService) { }
 
   ngOnInit() {
-    this.activatedroute.parent.params.pipe(take(1)).subscribe(params => {
-      this.getContratosLicitacaoByID(params.id);
-    });
-    this.activatedroute.queryParams.pipe(take(1)).subscribe(params => {
-      this.activeIds = ['panel-' + params.id];
-    });
-    this.radioGroupForm = this.formBuilder.group({
-      showTotal: false
-    });
-  }
-
-  getContratosLicitacaoByID(id: string) {
-    this.contratosLicitacao$ = this.licitacaoService.getContratos(id);
-  }
-
-  getMediaItensSemelhantes(dsItem: string[], dataInicioContrato: Date, unidadeMedida: string) {
-    const termos = [dsItem[0], dsItem.slice(0, 2).join(' & '), dsItem.join(' & ')];
-    return this.itensService.getItensSimilares(termos, dataInicioContrato, unidadeMedida)
-      .pipe(take(1),
-        map(itens => {
-          const itensOrdenados = itens.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
-          const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
-          const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
-          const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;
-          return { mediana, itensOrdenados };
-        })
-      ).toPromise();
-  }
-
-  getTipoFornecedor(tipoFornecedor: string): string {
-    if (tipoFornecedor === 'J') {
-      return 'Pessoa Jurídica';
-    } else if (tipoFornecedor === 'F') {
-      return 'Pessoa Física';
-    } else if (tipoFornecedor === 'C') {
-      return 'Consórcio';
-    }
-    return 'Outros';
-  }
-
-  defineCorFundo(valor: number): string {
-    const cor: any = d3.scaleLinear()
-    .domain([-1, 0, 1])
-    .range(['#72a5b6', '#ffffff', '#d7856c']);
-    return cor(valor);
-  }
-
-  defineCor(valor: number): string {
-    return (valor >= 1 || valor <= -1) ? 'white' : 'black';
-  }
-
-  open(content, item: ItensContrato): void {
-    this.itemSelecionado = item;
-    this.modalService.open(content, { ariaLabelledBy: 'modal-descricao', size: 'xl' });
+    this.contratosLicitacao$ = this.activatedroute.parent.params
+      .pipe(
+        take(1),
+        concatMap(params => this.licitacaoService.getContratos(params.id)
+        )
+      );
   }
 }

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
@@ -9,14 +9,9 @@
     <div class="row mt-4">
       <div class="col">
         <span
-          [hidden]="licitacao?.data_homologacao"
-          class="badge badge-info">
-          Licitação aberta
-        </span>
-        <span
-          [hidden]="!licitacao?.data_homologacao"
-          class="badge badge-danger">
-          Licitação encerrada
+          class="badge"
+          [ngClass]="licitacao?.status === 'Com contratos' ? 'badge-danger' : 'badge-info'">
+          {{ licitacao?.status }}
         </span>
         <div
           *ngIf="!licitacao?.merenda"
@@ -30,24 +25,21 @@
     <div class="row mt-4">
       <div
         class="col-sm-6 col-md-3 col-lg-2 mb-4"
-        [hidden]="!licitacao?.data_homologacao">
+        [hidden]="licitacao?.qt_contratos === 0">
         <div class="dados-linha">
-          <strong>Valor homologado</strong>
+          <strong>Valor contratado</strong>
         </div>
         <div class="dados-linha">
-          <span [hidden]="!licitacao?.vl_homologado">
-            {{ licitacao?.vl_homologado | currency: "R$" }}
-          </span>
-          <span [hidden]="licitacao?.vl_homologado">--</span>
+          {{ licitacao?.vl_contratado | currency: "R$" }}
         </div>
       </div>
       <div
         class="col-sm-6 col-md-3 col-lg-2 mb-4"
-        [hidden]="quantContratos == 0">
+        [hidden]="licitacao?.qt_contratos === 0">
         <div class="dados-linha">
           <strong>Contratos</strong>
         </div>
-        <div class="dados-linha">{{ quantContratos }}</div>
+        <div class="dados-linha">{{ licitacao?.qt_contratos }}</div>
       </div>
       <div class="col-sm-6 col-md-3 col-lg-4 mb-4">
         <div class="dados-linha">

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.ts
@@ -19,8 +19,6 @@ export class LicitacoesDetalharInfoComponent implements OnInit, OnDestroy {
   private unsubscribe = new Subject();
 
   public licitacao: Licitacao;
-  public valorContratado: number;
-  public quantContratos: number;
   public timeline: any[];
   public isLoading = true;
 
@@ -41,14 +39,11 @@ export class LicitacoesDetalharInfoComponent implements OnInit, OnDestroy {
       this.licitacaoService.getNovidades(id)
     ).pipe(takeUntil(this.unsubscribe)).subscribe(data => {
       this.licitacao = data[0];
+      this.licitacao.qt_contratos = this.licitacao.contratosLicitacao.length;
+      this.licitacao.status = this.licitacao.qt_contratos === 0 ? 'Sem contratos' : 'Com contratos';
+      this.licitacao.vl_contratado = this.licitacao.contratosLicitacao
+        .reduce((sum, contrato) => sum + contrato.vl_contrato, 0);
       const novidadesLicitacao = data[1];
-
-      this.valorContratado = data[0].contratosLicitacao.reduce((sum, contrato) => {
-        return sum + contrato.vl_contrato;
-      }, 0);
-
-      this.quantContratos = data[0].contratosLicitacao.length;
-
       const timeline = nest()
         .key((d: any) => d.data)
         .key((d: any) => d.id_tipo)

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/timeline/timeline.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/timeline/timeline.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="timeline.length">
+<div *ngIf="timeline?.length">
   <h4 class="titulo-sessao">Eventos</h4>
 
   <div class="timeline mb-4">

--- a/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.html
+++ b/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.html
@@ -1,7 +1,9 @@
 <h4 class="my-4 d-block d-sm-none">Contratos vigentes</h4>
 
-<p [hidden]="contratosVigentes?.length > 0 || isLoading">Não há contratos vigentes neste momento.</p>
+<p *ngIf="((contratosVigentes$ | async)?.length === 0) && (loading$ | async) === false">Não há contratos vigentes neste momento.</p>
 
-<app-spinner *ngIf="isLoading"></app-spinner>
+<app-spinner *ngIf="loading$ | async"></app-spinner>
 
-<app-lista-contratos [contratos]="contratosVigentes" [isLoading]="isLoading"></app-lista-contratos>
+<app-lista-contratos
+  *ngIf="((contratosVigentes$ | async)?.length > 0) && (loading$ | async) === false"
+  [contratos$]="contratosVigentes$"></app-lista-contratos>

--- a/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.html
+++ b/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.html
@@ -1,6 +1,8 @@
 <h4 class="my-4 d-block d-sm-none">Contratos vigentes</h4>
 
-<p *ngIf="((contratosVigentes$ | async)?.length === 0) && (loading$ | async) === false">Não há contratos vigentes neste momento.</p>
+<p *ngIf="((contratosVigentes$ | async)?.length === 0) && (loading$ | async) === false">
+  Não há contratos vigentes neste momento.
+</p>
 
 <app-spinner *ngIf="loading$ | async"></app-spinner>
 

--- a/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.ts
+++ b/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.ts
@@ -23,13 +23,9 @@ export class ContratosVigentesComponent implements OnInit {
   constructor(
     private userService: UserService,
     private contratoService: ContratoService
-    ) { }
+    ) {}
 
   ngOnInit() {
-    this.getMunicipio();
-  }
-
-  getMunicipio() {
     this.userService
       .getMunicipioEscolhido()
       .pipe(

--- a/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.ts
+++ b/client/src/app/municipio/contratos-vigentes/contratos-vigentes.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 
 import { Subject, Observable, BehaviorSubject } from 'rxjs';
-import { takeUntil, debounceTime, tap, startWith } from 'rxjs/operators';
+import { takeUntil, debounceTime } from 'rxjs/operators';
 
 import { UserService } from '../../shared/services/user.service';
 import { ContratoService } from '../../shared/services/contrato.service';
 import { ContratoLicitacao } from '../../shared/models/contratoLicitacao.model';
-import { ListaService } from 'src/app/shared/services/lista.service';
 
 @Component({
   selector: 'app-contratos-vigentes',

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -24,9 +24,13 @@
     <thead>
       <tr>
         <th scope="col"
+        ordenavel="nr_licitacao"
+        (ordenar)="onOrdenar($event)"
+        appOrdenavel>Licitação</th>
+        <th scope="col"
         ordenavel="descricao_objeto"
         (ordenar)="onOrdenar($event)"
-        appOrdenavel>Objeto da licitação</th>
+        appOrdenavel>Objeto</th>
         <th
           scope="col"
           class="text-center"
@@ -46,10 +50,13 @@
     </thead>
     <tbody>
       <tr *ngFor="let licitacao of listaService.dadosProcessados$ | async; index as i">
-        <td>
+        <td class="text-center">
           <a [routerLink]="['/licitacoes/' + licitacao.id_licitacao + '/info']">
-            <ngb-highlight [result]="licitacao.descricao_objeto | initialcase" [term]="listaService.termoBusca"></ngb-highlight>
+            <ngb-highlight [result]="licitacao.nr_licitacao" [term]="listaService.termoBusca"></ngb-highlight>
           </a>
+        </td>
+        <td>
+          <ngb-highlight [result]="licitacao.descricao_objeto | initialcase" [term]="listaService.termoBusca"></ngb-highlight>
         </td>
         <td class="text-center text-nowrap">
           {{ licitacao.data_abertura | date:'LLL/y' }}

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -30,7 +30,17 @@
         <th scope="col"
         ordenavel="descricao_objeto"
         (ordenar)="onOrdenar($event)"
-        appOrdenavel>Objeto</th>
+        appOrdenavel>
+        Objeto
+        </th>
+        <th
+          scope="col"
+          class="text-right"
+          ordenavel="vl_contratado"
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
+          Valor contratado
+        </th>
         <th
           scope="col"
           class="text-center"
@@ -57,6 +67,14 @@
         </td>
         <td>
           <ngb-highlight [result]="licitacao.descricao_objeto | initialcase" [term]="listaService.termoBusca"></ngb-highlight>
+        </td>
+        <td class="text-right">
+          <span *ngIf="licitacao?.qt_contratos !== 0; else semContratos">
+            {{ licitacao.vl_contratado | currency: "R$" }}
+          </span>
+          <ng-template #semContratos>
+            --
+          </ng-template>
         </td>
         <td class="text-center text-nowrap">
           {{ licitacao.data_abertura | date:'LLL/y' }}

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -1,31 +1,40 @@
 <h4 class="my-4 d-block d-sm-none">Licitações</h4>
 
-<p [hidden]="licitacoes?.length > 0 || isLoading">
+<p *ngIf="((listaService.dadosProcessados$ | async)?.length === 0) && (loading$ | async) === false">
   Não há licitações abertas neste momento.
 </p>
 
-<app-spinner *ngIf="isLoading"></app-spinner>
+<app-spinner *ngIf="loading$ | async"></app-spinner>
 
 <div class="table-responsive">
   <table
-    class="table table-sm table-hover"
-    [hidden]="licitacoes?.length == 0 || isLoading">
+    class="table table-hover"
+    *ngIf="((listaService.dadosProcessados$ | async)?.length > 0) && (loading$ | async) === false">
     <thead>
       <tr>
-        <th scope="col">Objeto da licitação</th>
+        <th scope="col"
+        ordenavel="descricao_objeto"
+        (ordenar)="onOrdenar($event)"
+        appOrdenavel>Objeto da licitação</th>
         <th
           scope="col"
-          class="text-center">
+          class="text-center"
+          ordenavel="data_abertura"
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Data de publicação
         </th>
         <th
-          scope="col">
+          scope="col"
+          ordenavel="status"
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
         Status
         </th>
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let licitacao of licitacoes">
+      <tr *ngFor="let licitacao of listaService.dadosProcessados$ | async; index as i">
         <td>
           <a [routerLink]="['/licitacoes/' + licitacao.id_licitacao + '/info']">
             {{ licitacao.descricao_objeto | initialcase }}

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -39,7 +39,7 @@
           ordenavel="vl_contratado"
           (ordenar)="onOrdenar($event)"
           appOrdenavel>
-          Valor contratado
+          Total contratado
         </th>
         <th
           scope="col"

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -1,7 +1,18 @@
 <h4 class="my-4 d-block d-sm-none">Licitações</h4>
 
+<form *ngIf="(loading$ | async) === false">
+  <div class="form-group">
+    <input
+      class="form-control"
+      type="text"
+      placeholder="Buscar nas licitações..."
+      name="termoBusca"
+      [(ngModel)]="listaService.termoBusca" />
+  </div>
+</form>
+
 <p *ngIf="((listaService.dadosProcessados$ | async)?.length === 0) && (loading$ | async) === false">
-  Não há licitações abertas neste momento.
+  Não há licitações.
 </p>
 
 <app-spinner *ngIf="loading$ | async"></app-spinner>
@@ -37,7 +48,7 @@
       <tr *ngFor="let licitacao of listaService.dadosProcessados$ | async; index as i">
         <td>
           <a [routerLink]="['/licitacoes/' + licitacao.id_licitacao + '/info']">
-            {{ licitacao.descricao_objeto | initialcase }}
+            <ngb-highlight [result]="licitacao.descricao_objeto | initialcase" [term]="listaService.termoBusca"></ngb-highlight>
           </a>
         </td>
         <td class="text-center text-nowrap">

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -19,7 +19,7 @@
 
 <div class="table-responsive">
   <table
-    class="table table-hover"
+    class="table table-sm table-hover"
     *ngIf="((listaService.dadosProcessados$ | async)?.length > 0) && (loading$ | async) === false">
     <thead>
       <tr>

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -63,16 +63,10 @@
         </td>
         <td class="text-center">
           <span
-            *ngIf="licitacao.status === 'Aberta'; else licitacaoEncerrada"
-            class="badge badge-info">
-            Aberta
+            class="badge"
+            [ngClass]="licitacao?.status === 'Com contratos' ? 'badge-danger' : 'badge-info'">
+            {{ licitacao?.status }}
           </span>
-          <ng-template #licitacaoEncerrada>
-            <span
-              class="badge badge-danger">
-              Encerrada
-            </span>
-          </ng-template>
         </td>
       </tr>
     </tbody>

--- a/client/src/app/municipio/licitacoes/licitacoes.component.html
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.html
@@ -41,7 +41,7 @@
           </a>
         </td>
         <td class="text-center text-nowrap">
-          {{ licitacao.data_abertura | date: "dd-MM-yyyy" }}
+          {{ licitacao.data_abertura | date:'LLL/y' }}
         </td>
         <td class="text-center">
           <span

--- a/client/src/app/municipio/licitacoes/licitacoes.component.scss
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.scss
@@ -32,9 +32,9 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e90d';
+  content: '\e911';
 }
 
 th[ordenavel].desc:before {
-  content: '\e911';
+  content: '\e90d';
 }

--- a/client/src/app/municipio/licitacoes/licitacoes.component.scss
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.scss
@@ -32,9 +32,9 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e911';
+  content: '\e90d';
 }
 
 th[ordenavel].desc:before {
-  content: '\e90d';
+  content: '\e911';
 }

--- a/client/src/app/municipio/licitacoes/licitacoes.component.scss
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.scss
@@ -1,0 +1,40 @@
+@font-face {
+  font-family: 'icomoon';
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4');
+  src:  url('../../../assets/fonts/icomoon.eot?fw8tb4#iefix') format('embedded-opentype'),
+    url('../../../assets/fonts/icomoon.ttf?fw8tb4') format('truetype'),
+    url('../../../assets/fonts/icomoon.woff?fw8tb4') format('woff'),
+    url('../../../assets/fonts/icomoon.svg?fw8tb4#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
+th[ordenavel] {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+th[ordenavel].asc:before, th[ordenavel].desc:before {
+  font-family: 'icomoon'!important;
+  display: inline;
+
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+th[ordenavel].asc:before {
+  content: '\e90d';
+}
+
+th[ordenavel].desc:before {
+  content: '\e911';
+}

--- a/client/src/app/municipio/licitacoes/licitacoes.component.ts
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.ts
@@ -44,7 +44,7 @@ export class LicitacoesComponent implements OnInit {
                 licitacao.vl_contratado = licitacao.contratosLicitacao
                   .reduce((sum, contrato) => sum + contrato.vl_contrato, 0);
               });
-              return licitacoes.slice().sort((l1, l2) => l2.status.localeCompare(l1.status));;
+              return licitacoes.slice().sort((l1, l2) => l2.status.localeCompare(l1.status));
             }),
             tap(() => this.loading$.next(false))
           );

--- a/client/src/app/municipio/licitacoes/licitacoes.component.ts
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.ts
@@ -1,57 +1,66 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChildren, QueryList } from '@angular/core';
 
-import { Subject } from 'rxjs';
-import { takeUntil, debounceTime } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
 
 import { UserService } from '../../shared/services/user.service';
 import { LicitacaoService } from '../../shared/services/licitacao.service';
-import { Licitacao } from '../../shared/models/licitacao.model';
+import { ListaLicitacoesService } from 'src/app/shared/services/lista.service';
+import { DecimalPipe } from '@angular/common';
+import { OrdenavelDirective } from 'src/app/shared/directives/ordenavel.directive';
+import { EventoOrd } from 'src/app/shared/models/lista.model';
+import { map, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-licitacoes',
   templateUrl: './licitacoes.component.html',
-  styleUrls: ['./licitacoes.component.scss']
+  styleUrls: ['./licitacoes.component.scss'],
+  providers: [ListaLicitacoesService, DecimalPipe]
 })
 export class LicitacoesComponent implements OnInit {
 
-  private unsubscribe = new Subject();
-
+  public loading$ = new BehaviorSubject<boolean>(true);
   public municipioEscolhido: string;
-  public licitacoes: Licitacao[];
-  public isLoading = true;
+
+  @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
   constructor(
     private userService: UserService,
-    private licitacaoService: LicitacaoService) { }
+    private licitacaoService: LicitacaoService,
+    public listaService: ListaLicitacoesService
+    ) { }
 
   ngOnInit() {
-    this.getMunicipio();
-  }
-
-  getMunicipio() {
     this.userService
       .getMunicipioEscolhido()
-      .pipe(
-        debounceTime(300),
-        takeUntil(this.unsubscribe))
       .subscribe(municipio => {
         this.municipioEscolhido = municipio;
-        this.getLicitacoes(this.municipioEscolhido);
+        this.listaService.dados$ = this.licitacaoService
+          .getLicitacoes(municipio)
+          .pipe(
+            map(licitacoes => {
+              // Adiciona status
+              licitacoes.map(licitacao => licitacao.status = licitacao.data_homologacao === null ? 'Aberta' : 'Encerrada');
+              // Ordena por status
+              licitacoes.sort((l1, l2) => l1.status.localeCompare(l2.status));
+              return licitacoes;
+            }),
+            tap(() => this.loading$.next(false))
+          );
       });
   }
 
-  getLicitacoes(municipio: string) {
-    this.licitacaoService.getLicitacoes(municipio)
-      .pipe(takeUntil(this.unsubscribe)).subscribe(licitacoes => {
-        this.licitacoes = licitacoes;
-        // Adiciona status
-        this.licitacoes
-          .map(licitacao => licitacao.status = licitacao.data_homologacao === null ? 'Aberta' : 'Encerrada');
-        // Ordena por status
-        this.licitacoes
-          .sort((l1, l2) => l1.status.localeCompare(l2.status));
-        this.isLoading = false;
-      });
+  onOrdenar({coluna, direcao}: EventoOrd) {
+    // Reseta outros cabeçalhos
+    this.cabecalhos.forEach(cab => {
+      if (cab.ordenavel !== coluna) {
+        cab.direcao = '';
+        cab.ordAsc = false;
+        cab.ordDesc = false;
+      }
+    });
+
+    this.listaService.colunaOrd = coluna;
+    this.listaService.direcaoOrd = direcao;
   }
 
 }

--- a/client/src/app/municipio/licitacoes/licitacoes.component.ts
+++ b/client/src/app/municipio/licitacoes/licitacoes.component.ts
@@ -38,11 +38,13 @@ export class LicitacoesComponent implements OnInit {
           .getLicitacoes(municipio)
           .pipe(
             map(licitacoes => {
-              // Adiciona status
-              licitacoes.map(licitacao => licitacao.status = licitacao.data_homologacao === null ? 'Aberta' : 'Encerrada');
-              // Ordena por status
-              licitacoes.sort((l1, l2) => l1.status.localeCompare(l2.status));
-              return licitacoes;
+              licitacoes.map(licitacao => {
+                licitacao.qt_contratos = licitacao.contratosLicitacao.length;
+                licitacao.status = licitacao.qt_contratos === 0 ? 'Sem contratos' : 'Com contratos';
+                licitacao.vl_contratado = licitacao.contratosLicitacao
+                  .reduce((sum, contrato) => sum + contrato.vl_contrato, 0);
+              });
+              return licitacoes.slice().sort((l1, l2) => l2.status.localeCompare(l1.status));;
             }),
             tap(() => this.loading$.next(false))
           );

--- a/client/src/app/municipio/municipio.module.ts
+++ b/client/src/app/municipio/municipio.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 import { NgxPaginationModule } from 'ngx-pagination';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { MunicipioComponent } from './municipio.component';
 import { MunicipioRoutingModule } from './municipio-routing.module';
@@ -27,7 +29,9 @@ import { NovidadeComponent } from './novidades/novidade/novidade.component';
     MunicipioRoutingModule,
     FilterModule,
     SharedModule,
-    PipesModule
+    PipesModule,
+    FormsModule,
+    NgbModule
   ]
 })
 export class MunicipioModule { }

--- a/client/src/app/shared/components/busca-municipio/busca-municipio.component.html
+++ b/client/src/app/shared/components/busca-municipio/busca-municipio.component.html
@@ -22,33 +22,32 @@
       id="navbarNav"
       class="collapse navbar-collapse"
       [ngClass]="{ 'show': navbarOpen }">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item active">
-          <button
-            class="btn btn-link nav-link"
-            (click)="toggleShow()">
-            <span class="icon-search"></span>
-            Buscar município
-          </button>
-        </li>
-        <li [hidden]="!show">
+      <ul class="navbar-nav ml-auto">
+        <li [hidden]="isURLHome">
           <div class="input-group">
             <input
+              [hidden]="!show"
               id="typeahead-focus"
               type="text"
-              class="form-control"
+              class="form-control inp-expandido"
               placeholder="{{placeholder}}"
               [(ngModel)]="municipioSelecionado"
               [ngbTypeahead]="search"
-              (focus)="focus$.next($event.target.value)"
-              (click)="click$.next($event.target.value)"
+              onclick="this.select()"
+              onfocus="this.select()"
+              (focus)="focus$.next($any($event).target.value)"
+              (click)="click$.next($any($event).target.value)"
               [editable]="false"
               (selectItem)="salvarMunicipio($event.item)"
               #instance="ngbTypeahead">
+            <button
+              class="btn btn-link btn-buscar nav-link"
+              [ngClass]="{'btn-retraido': show}"
+              (click)="toggleShow()">
+              <span class="icon-search"></span>
+            </button>
           </div>
         </li>
-      </ul>
-      <ul class="navbar-nav ml-auto">
         <li class="nav-item active">
           <a
             class="nav-link"

--- a/client/src/app/shared/components/busca-municipio/busca-municipio.component.scss
+++ b/client/src/app/shared/components/busca-municipio/busca-municipio.component.scss
@@ -9,6 +9,36 @@
   opacity: 1;
 }
 
+.btn-buscar {
+  color: #495057!important;
+  background-color: white;
+  height: calc(1.5em + 0.75rem + 4px);
+  line-height: 1.5pt;
+  margin-right: 5px;
+  padding-left: 3px!important;
+  padding-right: 7px!important;
+
+}
+
+.btn-buscar:after {
+  content: " Buscar município";
+}
+
+.btn-retraido {
+  border-bottom-left-radius: 0px;
+  border-top-left-radius: 0px;
+}
+
+.btn-retraido:after  {
+  content: none;
+}
+
+.inp-expandido {
+  border-bottom-right-radius: 0px;
+  border-top-right-radius: 0px;
+  border: 0px;
+}
+
 .hide-busca {
   opacity: 0;
 }
@@ -37,18 +67,6 @@
 
   > small {
     font-size: 0.8em;
-  }
-}
-
-.btn-buscar {
-  font-size: 0.6rem;
-
-  @media (min-width: 350px) {
-    font-size: 0.8rem;
-  }
-
-  @media (min-width: 576px) {
-    font-size: 1rem;
   }
 }
 

--- a/client/src/app/shared/components/busca-municipio/busca-municipio.component.ts
+++ b/client/src/app/shared/components/busca-municipio/busca-municipio.component.ts
@@ -5,7 +5,6 @@ import {
   debounceTime,
   distinctUntilChanged,
   takeUntil,
-  take,
   map,
   filter
 } from 'rxjs/operators';
@@ -14,7 +13,7 @@ import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap';
 
 import { MunicipioService } from '../../services/municipio.service';
 import { UserService } from '../../services/user.service';
-import { Router } from '@angular/router';
+import { Router, NavigationStart } from '@angular/router';
 
 @Component({
   selector: 'app-busca-municipio',
@@ -31,6 +30,7 @@ export class BuscaMunicipioComponent implements OnInit, OnDestroy {
   public municipioSelecionado: string;
   public municipioDisplay: string;
   public show = false;
+  public isURLHome = false;
   public navbarOpen = false;
 
   focus$ = new Subject<string>();
@@ -42,6 +42,11 @@ export class BuscaMunicipioComponent implements OnInit, OnDestroy {
     private userService: UserService
   ) {
     this.municipios = [];
+    router.events
+      .pipe(filter(event => event instanceof NavigationStart))
+      .subscribe((route: NavigationStart) => {
+        this.isURLHome = route.url === '/' || route.url === '/home';
+    });
   }
 
   ngOnInit() {

--- a/client/src/app/shared/components/descricao-item/descricao-item.component.html
+++ b/client/src/app/shared/components/descricao-item/descricao-item.component.html
@@ -28,6 +28,7 @@
     ...
   </button>
   <span
+    *ngIf="comUnidade"
     class="text-muted">
     ({{ item.qt_itens_contrato }} {{ item.sg_unidade_medida | lowercase }})
   </span>

--- a/client/src/app/shared/components/descricao-item/descricao-item.component.html
+++ b/client/src/app/shared/components/descricao-item/descricao-item.component.html
@@ -29,6 +29,6 @@
   </button>
   <span
     class="text-muted">
-    ({{ item.qt_itens_contrato }} {{ item.itensLicitacaoItensContrato.sg_unidade_medida | lowercase }})
+    ({{ item.qt_itens_contrato }} {{ item.sg_unidade_medida | lowercase }})
   </span>
 </div>

--- a/client/src/app/shared/components/descricao-item/descricao-item.component.ts
+++ b/client/src/app/shared/components/descricao-item/descricao-item.component.ts
@@ -12,6 +12,7 @@ export class DescricaoItemComponent implements OnInit {
   @Input() item: ItensContrato;
   @Input() temLink: boolean;
   @Input() itemResumido = true;
+  @Input() comUnidade = true;
 
   constructor() { }
 

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -1,85 +1,81 @@
-<div class="row">
-  <div class="col-lg-6">
-    <form>
-      <div class="form-group">
-        <input
-          class="form-control"
-          type="text"
-          [formControl]="filtro"
-          [hidden]="contratos?.length == 0 || isLoading"
-          placeholder="Buscar nos contratos...">
-      </div>
-    </form>
+<form>
+  <div class="form-group">
+    <input
+      class="form-control"
+      type="text"
+      placeholder="Buscar nos contratos..."
+      name="termoBusca"
+      [(ngModel)]="listaService.termoBusca" />
   </div>
-</div>
-<div class="table-wrapper">
-  <div class="table-responsive">
-    <table
-      class="table table-sm table-hover"
-      [hidden]="contratos?.length == 0 || isLoading">
-      <thead>
-        <tr>
-          <th
-            scope="col"
-            class="text-center">
-            Contrato
-          </th>
-          <th
-            scope="col"
-            class="th-espacoso">
-            Fornecedor
-          </th>
-          <th
-            scope="col"
-            class="text-center">
-            CPF/CNPJ
-          </th>
-          <th scope="col">Valor contratado</th>
-          <th
-            scope="col"
-            class="text-center">
-            Início da vigência
-          </th>
-          <th
-            scope="col"
-            class="text-center">
-            Fim da vigência
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let contrato of contratos$ | async; index as i">
-          <td class="text-center">
-            <a [routerLink]="['/contratos/' + contrato.id_contrato]">
-              <ngb-highlight
-                [result]="contrato.nr_contrato"
-                [term]="filtro.value"></ngb-highlight>
-            </a>
-          </td>
-          <td>
-            <span *ngIf="contrato.contratoFornecedor.nm_pessoa">
-              <ngb-highlight
-                [result]="contrato.contratoFornecedor.nm_pessoa"
-                [term]="filtro.value"></ngb-highlight>
+</form>
+<div class="table-responsive">
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th
+          scope="col"
+          class="text-center"
+          ordenavel="nr_contrato"
+          (ordenar)="onOrdenar($event)">
+          Contrato
+        </th>
+        <th
+          scope="col"
+          class="th-espacoso"
+          ordenavel="nm_fornecedor"
+          (ordenar)="onOrdenar($event)">
+          Fornecedor
+        </th>
+        <th
+          scope="col"
+          class="text-center"
+          ordenavel="nr_documento_contratado"
+          (ordenar)="onOrdenar($event)">
+          CPF/CNPJ
+        </th>
+        <th scope="col">Valor contratado</th>
+        <th
+          scope="col"
+          class="text-center"
+          ordenavel="dt_inicio_vigencia"
+          (ordenar)="onOrdenar($event)">
+          Início da vigência
+        </th>
+        <th
+          scope="col"
+          class="text-center"
+          ordenavel="dt_final_vigencia"
+          (ordenar)="onOrdenar($event)">
+          Fim da vigência
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let contrato of listaService.dadosProcessados$ | async; index as i">
+        <td class="text-center">
+          <a [routerLink]="['/contratos/' + contrato.id_contrato]">
+            <ngb-highlight [result]="contrato.nr_contrato" [term]="listaService.termoBusca"></ngb-highlight>
+          </a>
+        </td>
+        <td>
+          <span *ngIf="contrato.contratoFornecedor.nm_pessoa">
+              <ngb-highlight [result]="contrato.contratoFornecedor.nm_pessoa" [term]="listaService.termoBusca"></ngb-highlight>
             </span>
             <span *ngIf="!contrato.contratoFornecedor.nm_pessoa">(Nome não encontrado)</span>
-          </td>
-          <td class="text-right numero">
-            <ngb-highlight
-              [result]="contrato.nr_documento_contratado | formatCpfCnpj"
-              [term]="filtro.value"></ngb-highlight>
-          </td>
-          <td class="text-right numero">
-            {{ contrato.vl_contrato | currency: "R$" }}
-          </td>
-          <td class="text-center">
-            {{ contrato.dt_inicio_vigencia | date:'LLL/y' }}
-          </td>
-          <td class="text-center">
-            {{ contrato.dt_final_vigencia | date:'LLL/y' }}
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+        </td>
+        <td class="text-right numero">
+          <ngb-highlight [result]="contrato.nr_documento_contratado | formatCpfCnpj" [term]="listaService.termoBusca"></ngb-highlight>
+        </td>
+        <td class="text-right numero">
+          {{ contrato.vl_contrato | currency: "R$" }}
+        </td>
+        <td class="text-center">
+          {{ contrato.dt_inicio_vigencia | date:'LLL/y' }}
+        </td>
+        <td class="text-center">
+          {{ contrato.dt_final_vigencia | date:'LLL/y' }}
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -63,10 +63,10 @@
           </a>
         </td>
         <td>
-          <span *ngIf="contrato.contratoFornecedor.nm_pessoa">
-              <ngb-highlight [result]="contrato.contratoFornecedor.nm_pessoa" [term]="listaService.termoBusca"></ngb-highlight>
+          <span *ngIf="contrato.nm_fornecedor">
+              <ngb-highlight [result]="contrato.nm_fornecedor" [term]="listaService.termoBusca"></ngb-highlight>
             </span>
-            <span *ngIf="!contrato.contratoFornecedor.nm_pessoa">(Nome não encontrado)</span>
+            <span *ngIf="!contrato.nm_fornecedor">(Nome não encontrado)</span>
         </td>
         <td class="text-right numero">
           <ngb-highlight [result]="contrato.nr_documento_contratado | formatCpfCnpj" [term]="listaService.termoBusca"></ngb-highlight>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -14,7 +14,7 @@
       <tr>
         <th
           scope="col"
-          class="text-center"
+          class="text-center th-medio"
           ordenavel="nr_contrato"
           (ordenar)="onOrdenar($event)">
           Contrato
@@ -35,20 +35,21 @@
         </th>
         <th
           scope="col"
+          class="text-center"
           ordenavel="vl_contrato"
           (ordenar)="onOrdenar($event)">
           Valor contratado
         </th>
         <th
           scope="col"
-          class="text-center"
+          class="text-center th-medio"
           ordenavel="dt_inicio_vigencia"
           (ordenar)="onOrdenar($event)">
           Início da vigência
         </th>
         <th
           scope="col"
-          class="text-center"
+          class="text-center th-medio"
           ordenavel="dt_final_vigencia"
           (ordenar)="onOrdenar($event)">
           Fim da vigência

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -1,93 +1,99 @@
-<form>
-  <div class="form-group">
-    <input
-      class="form-control"
-      type="text"
-      placeholder="Buscar nos contratos..."
-      name="termoBusca"
-      [(ngModel)]="listaService.termoBusca" />
+<div class="row">
+  <div class="col-lg-6">
+    <form>
+      <div class="form-group">
+        <input
+          class="form-control"
+          type="text"
+          placeholder="Buscar nos contratos..."
+          name="termoBusca"
+          [(ngModel)]="listaService.termoBusca" />
+      </div>
+    </form>
   </div>
-</form>
-<div class="table-responsive">
-  <table class="table table-hover">
-    <thead>
-      <tr>
-        <th
-          scope="col"
-          class="text-center th-medio"
-          ordenavel="nr_contrato"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          Contrato
-        </th>
-        <th
-          scope="col"
-          class="th-espacoso"
-          ordenavel="nm_fornecedor"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          Fornecedor
-        </th>
-        <th
-          scope="col"
-          class="text-center"
-          ordenavel="nr_documento_contratado"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          CPF/CNPJ
-        </th>
-        <th
-          scope="col"
-          class="text-center"
-          ordenavel="vl_contrato"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          Valor contratado
-        </th>
-        <th
-          scope="col"
-          class="text-center th-medio"
-          ordenavel="dt_inicio_vigencia"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          Início da vigência
-        </th>
-        <th
-          scope="col"
-          class="text-center th-medio"
-          ordenavel="dt_final_vigencia"
-          (ordenar)="onOrdenar($event)"
-          appOrdenavel>
-          Fim da vigência
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let contrato of listaService.dadosProcessados$ | async; index as i">
-        <td class="text-center">
-          <a [routerLink]="['/contratos/' + contrato.id_contrato]">
-            <ngb-highlight [result]="contrato.nr_contrato" [term]="listaService.termoBusca"></ngb-highlight>
-          </a>
-        </td>
-        <td>
-          <span *ngIf="contrato.nm_fornecedor">
-              <ngb-highlight [result]="contrato.nm_fornecedor" [term]="listaService.termoBusca"></ngb-highlight>
-            </span>
-            <span *ngIf="!contrato.nm_fornecedor">(Nome não encontrado)</span>
-        </td>
-        <td class="text-right numero">
-          <ngb-highlight [result]="contrato.nr_documento_contratado | formatCpfCnpj" [term]="listaService.termoBusca"></ngb-highlight>
-        </td>
-        <td class="text-right numero">
-          {{ contrato.vl_contrato | currency: "R$" }}
-        </td>
-        <td class="text-center">
-          {{ contrato.dt_inicio_vigencia | date:'LLL/y' }}
-        </td>
-        <td class="text-center">
-          {{ contrato.dt_final_vigencia | date:'LLL/y' }}
-        </td>
-      </tr>
-    </tbody>
-  </table>
+</div>
+<div class="table-wrapper">
+  <div class="table-responsive">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th
+            scope="col"
+            class="text-center"
+            ordenavel="nr_contrato"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            Contrato
+          </th>
+          <th
+            scope="col"
+            class="th-espacoso"
+            ordenavel="nm_fornecedor"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            Fornecedor
+          </th>
+          <th
+            scope="col"
+            class="text-center"
+            ordenavel="nr_documento_contratado"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            CPF/CNPJ
+          </th>
+          <th
+            scope="col"
+            class="text-center"
+            ordenavel="vl_contrato"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            Valor contratado
+          </th>
+          <th
+            scope="col"
+            class="text-center"
+            ordenavel="dt_inicio_vigencia"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            Início da vigência
+          </th>
+          <th
+            scope="col"
+            class="text-center"
+            ordenavel="dt_final_vigencia"
+            (ordenar)="onOrdenar($event)"
+            appOrdenavel>
+            Fim da vigência
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let contrato of listaService.dadosProcessados$ | async; index as i">
+          <td class="text-center">
+            <a [routerLink]="['/contratos/' + contrato.id_contrato]">
+              <ngb-highlight [result]="contrato.nr_contrato" [term]="listaService.termoBusca"></ngb-highlight>
+            </a>
+          </td>
+          <td>
+            <span *ngIf="contrato.nm_fornecedor">
+                <ngb-highlight [result]="contrato.nm_fornecedor" [term]="listaService.termoBusca"></ngb-highlight>
+              </span>
+              <span *ngIf="!contrato.nm_fornecedor">(Nome não encontrado)</span>
+          </td>
+          <td class="text-right numero">
+            <ngb-highlight [result]="contrato.nr_documento_contratado | formatCpfCnpj" [term]="listaService.termoBusca"></ngb-highlight>
+          </td>
+          <td class="text-right numero">
+            {{ contrato.vl_contrato | currency: "R$" }}
+          </td>
+          <td class="text-center">
+            {{ contrato.dt_inicio_vigencia | date:'LLL/y' }}
+          </td>
+          <td class="text-center">
+            {{ contrato.dt_final_vigencia | date:'LLL/y' }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -33,7 +33,12 @@
           (ordenar)="onOrdenar($event)">
           CPF/CNPJ
         </th>
-        <th scope="col">Valor contratado</th>
+        <th
+          scope="col"
+          ordenavel="vl_contrato"
+          (ordenar)="onOrdenar($event)">
+          Valor contratado
+        </th>
         <th
           scope="col"
           class="text-center"

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -19,7 +19,7 @@
         <tr>
           <th
             scope="col"
-            class="text-center"
+            class="text-center th-medio"
             ordenavel="nr_contrato"
             (ordenar)="onOrdenar($event)"
             appOrdenavel>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.html
@@ -16,42 +16,48 @@
           scope="col"
           class="text-center th-medio"
           ordenavel="nr_contrato"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Contrato
         </th>
         <th
           scope="col"
           class="th-espacoso"
           ordenavel="nm_fornecedor"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Fornecedor
         </th>
         <th
           scope="col"
           class="text-center"
           ordenavel="nr_documento_contratado"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           CPF/CNPJ
         </th>
         <th
           scope="col"
           class="text-center"
           ordenavel="vl_contrato"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Valor contratado
         </th>
         <th
           scope="col"
           class="text-center th-medio"
           ordenavel="dt_inicio_vigencia"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Início da vigência
         </th>
         <th
           scope="col"
           class="text-center th-medio"
           ordenavel="dt_final_vigencia"
-          (ordenar)="onOrdenar($event)">
+          (ordenar)="onOrdenar($event)"
+          appOrdenavel>
           Fim da vigência
         </th>
       </tr>

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
@@ -1,3 +1,35 @@
+@font-face {
+  font-family: 'icomoon';
+  src:  url('../../../../assets/fonts/icomoon.eot?fw8tb4');
+  src:  url('../../../../assets/fonts/icomoon.eot?fw8tb4#iefix') format('embedded-opentype'),
+    url('../../../../assets/fonts/icomoon.ttf?fw8tb4') format('truetype'),
+    url('../../../../assets/fonts/icomoon.woff?fw8tb4') format('woff'),
+    url('../../../../assets/fonts/icomoon.svg?fw8tb4#icomoon') format('svg');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
+
 .th-espacoso {
   min-width: 180px;
+}
+
+th[ordenavel] {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+th[ordenavel].desc:before, th[ordenavel].asc:before {
+  content: '\e90d';
+  display: block;
+  background-size: 22px;
+  width: 22px;
+  height: 22px;
+  float: left;
+  margin-left: -22px;
+}
+
+th[ordenavel].desc:before {
+  content: '\e911';
 }

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
@@ -40,9 +40,9 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e911';
+  content: '\e90d';
 }
 
 th[ordenavel].desc:before {
-  content: '\e90d';
+  content: '\e911';
 }

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
@@ -14,20 +14,33 @@
   min-width: 180px;
 }
 
+.th-medio {
+  min-width: 120px;
+}
+
 th[ordenavel] {
   cursor: pointer;
   user-select: none;
   -webkit-user-select: none;
 }
 
-th[ordenavel].desc:before, th[ordenavel].asc:before {
+th[ordenavel].asc:before, th[ordenavel].desc:before {
+  font-family: 'icomoon'!important;
+  display: inline;
+
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+
+  /* Better Font Rendering =========== */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+th[ordenavel].asc:before {
   content: '\e90d';
-  display: block;
-  background-size: 22px;
-  width: 22px;
-  height: 22px;
-  float: left;
-  margin-left: -22px;
 }
 
 th[ordenavel].desc:before {

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.scss
@@ -40,9 +40,9 @@ th[ordenavel].asc:before, th[ordenavel].desc:before {
 }
 
 th[ordenavel].asc:before {
-  content: '\e90d';
+  content: '\e911';
 }
 
 th[ordenavel].desc:before {
-  content: '\e911';
+  content: '\e90d';
 }

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
@@ -1,9 +1,7 @@
-import { Component, OnInit, Input, PipeTransform, OnChanges, SimpleChanges, ViewChildren, QueryList } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewChildren, QueryList } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
-import { FormControl } from '@angular/forms';
 
-import { Observable, BehaviorSubject, Subject } from 'rxjs';
-import { map, startWith } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 import { ContratoLicitacao } from '../../models/contratoLicitacao.model';
 import { EventoOrd } from '../../models/lista.model';
@@ -27,7 +25,7 @@ export class ListaContratosComponent implements OnChanges {
     this.listaService.dados$ = this.contratos$;
   }
 
-  onOrdenar({coluna, direcao} : EventoOrd) {
+  onOrdenar({coluna, direcao}: EventoOrd) {
     // Reseta outros cabeçalhos
     this.cabecalhos.forEach(cab => {
       if (cab.ordenavel !== coluna) {

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
@@ -30,6 +30,8 @@ export class ListaContratosComponent implements OnChanges {
     this.cabecalhos.forEach(cab => {
       if (cab.ordenavel !== coluna) {
         cab.direcao = '';
+        cab.ordAsc = false;
+        cab.ordDesc = false;
       }
     });
 

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
@@ -21,10 +21,21 @@ export class ListaContratosComponent implements OnChanges {
 
   @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
-  constructor(
-    public listaService: ListaService
-  ) {}
+  constructor(public listaService: ListaService) {}
+
   ngOnChanges(changes: SimpleChanges): void {
     this.listaService.dados$ = this.contratos$;
+  }
+
+  onOrdenar({coluna, direcao} : EventoOrd) {
+    // Reseta outros cabeçalhos
+    this.cabecalhos.forEach(cab => {
+      if (cab.ordenavel !== coluna) {
+        cab.direcao = '';
+      }
+    });
+
+    this.listaService.colunaOrd = coluna;
+    this.listaService.direcaoOrd = direcao;
   }
 }

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
@@ -1,45 +1,30 @@
-import { Component, OnInit, Input, PipeTransform, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, OnInit, Input, PipeTransform, OnChanges, SimpleChanges, ViewChildren, QueryList } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { FormControl } from '@angular/forms';
 
-import { Observable } from 'rxjs';
+import { Observable, BehaviorSubject, Subject } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 
 import { ContratoLicitacao } from '../../models/contratoLicitacao.model';
+import { EventoOrd } from '../../models/lista.model';
+import { ListaService } from '../../services/lista.service';
+import { OrdenavelDirective } from '../../directives/ordenavel.directive';
 
 @Component({
   selector: 'app-lista-contratos',
   templateUrl: './lista-contratos.component.html',
   styleUrls: ['./lista-contratos.component.scss'],
-  providers: [DecimalPipe]
+  providers: [ListaService, DecimalPipe]
 })
-export class ListaContratosComponent implements OnInit, OnChanges {
-  @Input() contratos: ContratoLicitacao[];
-  @Input() isLoading: boolean;
+export class ListaContratosComponent implements OnChanges {
+  @Input() contratos$: Observable<ContratoLicitacao[]>;
 
-  contratos$: Observable<ContratoLicitacao[]>;
-  filtro = new FormControl();
+  @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
-  constructor(private pipe: DecimalPipe) {
-  }
+  constructor(
+    public listaService: ListaService
+  ) {}
   ngOnChanges(changes: SimpleChanges): void {
-    this.contratos$ = this.filtro.valueChanges.pipe(
-      startWith(''),
-      map(texto => this.buscar(texto, this.pipe))
-    );
-  }
-
-  ngOnInit() {
-  }
-
-  buscar(texto: string, pipe: PipeTransform): ContratoLicitacao[] {
-    if (this.contratos) {
-      return this.contratos.filter(contrato => {
-        const termo = texto.toLowerCase();
-        return pipe.transform(contrato.nr_contrato).includes(termo)
-            || contrato.contratoFornecedor.nm_pessoa.toLowerCase().includes(termo)
-            || pipe.transform(contrato.nr_documento_contratado).includes(termo);
-      });
-    }
+    this.listaService.dados$ = this.contratos$;
   }
 }

--- a/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
+++ b/client/src/app/shared/components/lista-contratos/lista-contratos.component.ts
@@ -5,21 +5,21 @@ import { Observable } from 'rxjs';
 
 import { ContratoLicitacao } from '../../models/contratoLicitacao.model';
 import { EventoOrd } from '../../models/lista.model';
-import { ListaService } from '../../services/lista.service';
+import { ListaContratosService } from '../../services/lista.service';
 import { OrdenavelDirective } from '../../directives/ordenavel.directive';
 
 @Component({
   selector: 'app-lista-contratos',
   templateUrl: './lista-contratos.component.html',
   styleUrls: ['./lista-contratos.component.scss'],
-  providers: [ListaService, DecimalPipe]
+  providers: [ListaContratosService, DecimalPipe]
 })
 export class ListaContratosComponent implements OnChanges {
   @Input() contratos$: Observable<ContratoLicitacao[]>;
 
   @ViewChildren(OrdenavelDirective) cabecalhos: QueryList<OrdenavelDirective>;
 
-  constructor(public listaService: ListaService) {}
+  constructor(public listaService: ListaContratosService) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     this.listaService.dados$ = this.contratos$;

--- a/client/src/app/shared/components/shared.module.ts
+++ b/client/src/app/shared/components/shared.module.ts
@@ -14,6 +14,7 @@ import { ListaContratosComponent } from './lista-contratos/lista-contratos.compo
 import { PipesModule } from '../pipes/pipes.module';
 import { BarraTituloComponent } from './barra-titulo/barra-titulo.component';
 import { DescricaoItemComponent } from './descricao-item/descricao-item.component';
+import { OrdenavelDirective } from '../directives/ordenavel.directive';
 
 @NgModule({
   declarations: [
@@ -24,7 +25,8 @@ import { DescricaoItemComponent } from './descricao-item/descricao-item.componen
     ListaContratosComponent,
     ProgressComponent,
     BarraTituloComponent,
-    DescricaoItemComponent
+    DescricaoItemComponent,
+    OrdenavelDirective
   ],
   imports: [
     CommonModule,
@@ -42,7 +44,8 @@ import { DescricaoItemComponent } from './descricao-item/descricao-item.componen
     ListaContratosComponent,
     ProgressComponent,
     BarraTituloComponent,
-    DescricaoItemComponent
+    DescricaoItemComponent,
+    OrdenavelDirective
   ]
 })
 export class SharedModule { }

--- a/client/src/app/shared/directives/ordenavel.directive.spec.ts
+++ b/client/src/app/shared/directives/ordenavel.directive.spec.ts
@@ -1,0 +1,8 @@
+import { OrdenavelDirective } from './ordenavel.directive';
+
+describe('OrdenavelDirective', () => {
+  it('should create an instance', () => {
+    const directive = new OrdenavelDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/client/src/app/shared/directives/ordenavel.directive.ts
+++ b/client/src/app/shared/directives/ordenavel.directive.ts
@@ -1,15 +1,10 @@
-import { Directive, Input, Output, EventEmitter } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, HostBinding, HostListener, Host } from '@angular/core';
 import { DirecaoOrd, EventoOrd } from '../models/lista.model';
 
-const trocar: {[key: string]: DirecaoOrd} = { 'asc': 'desc', 'desc': '', '': 'asc' };
+const trocar: {[key: string]: DirecaoOrd} = { asc: 'desc', desc: '', '': 'asc' };
 
 @Directive({
-  selector: 'th[ordenavel]',
-  host: {
-    '[class.asc]': 'direcao === "asc"',
-    '[class.desc]': 'direcao === "desc"',
-    '(click)': 'trocar()'
-  }
+  selector: 'th[appOrdenavel]'
 })
 export class OrdenavelDirective {
 
@@ -19,8 +14,14 @@ export class OrdenavelDirective {
   @Input() direcao: DirecaoOrd = '';
   @Output() ordenar = new EventEmitter<EventoOrd>();
 
+  @HostBinding('class.asc') ordAsc = false;
+  @HostBinding('class.desc') ordDesc = false;
+
+  @HostListener('click')
   trocar() {
     this.direcao = trocar[this.direcao];
+    this.ordAsc = this.direcao === 'asc';
+    this.ordDesc = this.direcao === 'desc';
     this.ordenar.emit({coluna: this.ordenavel, direcao: this.direcao});
   }
 }

--- a/client/src/app/shared/directives/ordenavel.directive.ts
+++ b/client/src/app/shared/directives/ordenavel.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input, Output, EventEmitter, HostBinding, HostListener, Host } from '@angular/core';
 import { DirecaoOrd, EventoOrd } from '../models/lista.model';
 
-const trocar: {[key: string]: DirecaoOrd} = { asc: '', desc: 'asc', '': 'desc' };
+const trocar: {[key: string]: DirecaoOrd} = { asc: 'desc', desc: '', '': 'asc' };
 
 @Directive({
   selector: 'th[appOrdenavel]'

--- a/client/src/app/shared/directives/ordenavel.directive.ts
+++ b/client/src/app/shared/directives/ordenavel.directive.ts
@@ -1,7 +1,7 @@
 import { Directive, Input, Output, EventEmitter, HostBinding, HostListener, Host } from '@angular/core';
 import { DirecaoOrd, EventoOrd } from '../models/lista.model';
 
-const trocar: {[key: string]: DirecaoOrd} = { asc: 'desc', desc: '', '': 'asc' };
+const trocar: {[key: string]: DirecaoOrd} = { asc: '', desc: 'asc', '': 'desc' };
 
 @Directive({
   selector: 'th[appOrdenavel]'

--- a/client/src/app/shared/directives/ordenavel.directive.ts
+++ b/client/src/app/shared/directives/ordenavel.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, Input, Output, EventEmitter } from '@angular/core';
+import { DirecaoOrd, EventoOrd } from '../models/lista.model';
+
+const trocar: {[key: string]: DirecaoOrd} = { 'asc': 'desc', 'desc': '', '': 'asc' };
+
+@Directive({
+  selector: 'th[ordenavel]',
+  host: {
+    '[class.asc]': 'direcao === "asc"',
+    '[class.desc]': 'direcao === "desc"',
+    '(click)': 'trocar()'
+  }
+})
+export class OrdenavelDirective {
+
+  constructor() { }
+
+  @Input() ordenavel: string;
+  @Input() direcao: DirecaoOrd = '';
+  @Output() ordenar = new EventEmitter<EventoOrd>();
+
+  trocar() {
+    this.direcao = trocar[this.direcao];
+    this.ordenar.emit({coluna: this.ordenavel, direcao: this.direcao});
+  }
+}

--- a/client/src/app/shared/models/contratoLicitacao.model.ts
+++ b/client/src/app/shared/models/contratoLicitacao.model.ts
@@ -16,6 +16,7 @@ export interface ContratoLicitacao {
   dt_inicio_vigencia: Date;
   dt_final_vigencia: Date;
   itensContrato: ItensContrato[];
+  contratoFornecedor: any;
   ano_contrato: number;
   id_contrato: string;
   total_pago: number;

--- a/client/src/app/shared/models/contratoLicitacao.model.ts
+++ b/client/src/app/shared/models/contratoLicitacao.model.ts
@@ -3,6 +3,8 @@ import { Fornecedor } from './fornecedor.model';
 
 export interface ContratoLicitacao {
   nm_orgao: string;
+  nm_fornecedor: string;
+  tp_fornecedor: string;
   id_licitacao: number;
   nr_licitacao: number;
   ano_licitacao: number;
@@ -13,7 +15,6 @@ export interface ContratoLicitacao {
   vl_contrato: number;
   dt_inicio_vigencia: Date;
   dt_final_vigencia: Date;
-  contratoFornecedor: Fornecedor;
   itensContrato: ItensContrato[];
   ano_contrato: number;
   id_contrato: string;

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -20,4 +20,5 @@ export interface ItensContrato {
   nome_municipio: string;
   itensContratoOrgao: any;
   resumido: boolean;
+  sg_unidade_medida: string;
 }

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -20,5 +20,4 @@ export interface ItensContrato {
   nome_municipio: string;
   itensContratoOrgao: any;
   resumido: boolean;
-  sg_unidade_medida: string;
 }

--- a/client/src/app/shared/models/itensContrato.model.ts
+++ b/client/src/app/shared/models/itensContrato.model.ts
@@ -12,6 +12,8 @@ export interface ItensContrato {
   qt_itens_contrato: number;
   vl_item_contrato: number;
   vl_total_item_contrato: number;
+  vl_unitario_estimado: number;
+  sg_unidade_medida: string;
   ds_item: string;
   ds_item_resumido: string;
   dt_inicio_vigencia: Date;

--- a/client/src/app/shared/models/licitacao.model.ts
+++ b/client/src/app/shared/models/licitacao.model.ts
@@ -15,6 +15,8 @@ export interface Licitacao {
   data_homologacao: Date;
   data_adjudicacao: Date;
   vl_homologado: number;
+  qt_contratos: number;
+  vl_contratado: number;
   descricao_objeto: string;
   merenda: boolean;
   contratosLicitacao: ContratoLicitacao[];

--- a/client/src/app/shared/models/lista.model.ts
+++ b/client/src/app/shared/models/lista.model.ts
@@ -1,0 +1,19 @@
+import { ContratoLicitacao } from "./contratoLicitacao.model";
+import { Licitacao } from './licitacao.model';
+
+export type DirecaoOrd = 'asc' | 'desc' | '';
+
+export interface EventoOrd {
+  coluna: string;
+  direcao: DirecaoOrd;
+}
+
+export interface ResultadoBusca {
+  dados: any[];
+}
+
+export interface EstadoLista {
+  termoBusca: string;
+  colunaOrd: string;
+  direcaoOrd: DirecaoOrd;
+}

--- a/client/src/app/shared/models/lista.model.ts
+++ b/client/src/app/shared/models/lista.model.ts
@@ -1,15 +1,8 @@
-import { ContratoLicitacao } from "./contratoLicitacao.model";
-import { Licitacao } from './licitacao.model';
-
 export type DirecaoOrd = 'asc' | 'desc' | '';
 
 export interface EventoOrd {
   coluna: string;
   direcao: DirecaoOrd;
-}
-
-export interface ResultadoBusca {
-  dados: any[];
 }
 
 export interface EstadoLista {

--- a/client/src/app/shared/pipes/termos-importantes.pipe.ts
+++ b/client/src/app/shared/pipes/termos-importantes.pipe.ts
@@ -6,11 +6,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class TermosImportantesPipe implements PipeTransform {
 
   transform(texto: string, n: number = 3): string[] {
-    return texto
+    const termos = texto
       .split(/\s+|:|-/)
       .slice(0, n)
       .map(palavra => palavra.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, ''))
       .filter(i => i !== '');
+    return [termos[0], termos.slice(0, 2).join(' & '), termos.join(' & ')];
   }
 
 }

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -32,7 +32,7 @@ export class ItensService {
       return this.getItensSimilares(termos, item.dt_inicio_vigencia)
         .pipe(take(1),
           map(itens => {
-            const itensOrdenados = itens.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
+            const itensOrdenados = itens.sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
             const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
             const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
             const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -25,7 +25,8 @@ export class ItensService {
   }
 
   getItensSimilares(item: ItensContrato, termos: string[]): Observable<ItensContrato[]> {
-      return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: termos, data: item.dt_inicio_vigencia });
+      return this.http.post<ItensContrato[]>(this.url + '/similares',
+        { termo: termos, data: item.dt_inicio_vigencia, unidade: item.sg_unidade_medida });
   }
 
   getMediaItensSemelhantes(item: ItensContrato, termos: string[]): Observable<ItensContrato> {

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -20,26 +20,26 @@ export class ItensService {
     return this.http.get<ItensContrato>(`${this.url}/item/${idItem}`);
   }
 
-    getByContrato(idContrato: string): Observable<ItensContrato[]> {
-      return this.http.get<ItensContrato[]>(`${this.url}/contrato/${idContrato}`);
-    }
+  getByContrato(idContrato: string): Observable<ItensContrato[]> {
+    return this.http.get<ItensContrato[]>(`${this.url}/contrato/${idContrato}`);
+  }
 
-    getItensSimilares(termos: string[], dataInicioContrato: Date): Observable<ItensContrato[]> {
-        return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: termos, data: dataInicioContrato });
-    }
+  getItensSimilares(item: ItensContrato, termos: string[]): Observable<ItensContrato[]> {
+      return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: termos, data: item.dt_inicio_vigencia });
+  }
 
-    getMediaItensSemelhantes(item: ItensContrato, termos: string[]): Observable<ItensContrato> {
-      return this.getItensSimilares(termos, item.dt_inicio_vigencia)
-        .pipe(take(1),
-          map(itens => {
-            const itensOrdenados = itens.sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
-            const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
-            const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
-            const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;
-            item.mediana_valor = mediana;
-            item.itensSemelhantes = itensOrdenados;
-            return item;
-          })
-        );
-    }
+  getMediaItensSemelhantes(item: ItensContrato, termos: string[]): Observable<ItensContrato> {
+    return this.getItensSimilares(item, termos)
+      .pipe(take(1),
+        map(itens => {
+          const itensOrdenados = itens.sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
+          const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
+          const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
+          const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;
+          item.mediana_valor = mediana;
+          item.itensSemelhantes = itensOrdenados;
+          return item;
+        })
+      );
+  }
 }

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -28,21 +28,19 @@ export class ItensService {
         return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: termos, data: dataInicioContrato });
     }
 
-  getMediaItensSemelhantes(termos: string[], dataInicioContrato: Date, unidadeMedida: string) {
-    const strTermos = [termos[0], termos.slice(0, 2).join(' & '), termos.join(' & ')];
-    return this.getItensSimilares(strTermos, dataInicioContrato, unidadeMedida)
-      .pipe(take(1),
-        map(itens => {
-          const itensOrdenados = itens.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
-          if (itensOrdenados.length > 0) {
+    getMediaItensSemelhantes(item: ItensContrato, termos: string[]): Observable<ItensContrato> {
+      const strTermos = [termos[0], termos.slice(0, 2).join(' & '), termos.join(' & ')];
+      return this.getItensSimilares(strTermos, item.dt_inicio_vigencia)
+        .pipe(take(1),
+          map(itens => {
+            const itensOrdenados = itens.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
             const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
             const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);
             const mediana = (itensOrdenados[meioInf].vl_item_contrato + itensOrdenados[meioSup].vl_item_contrato) / 2;
-            return { mediana, itensOrdenados };
-          }
-          //  retorna undefined caso não seja possível calcular a mediana
-          return { mediana: undefined, itensOrdenados };
-        })
-      ).toPromise();
-  }
+            item.mediana_valor = mediana;
+            item.itensSemelhantes = itensOrdenados;
+            return item;
+          })
+        );
+    }
 }

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -20,10 +20,13 @@ export class ItensService {
     return this.http.get<ItensContrato>(`${this.url}/item/${idItem}`);
   }
 
-  getItensSimilares(termos: string[], dataInicioContrato: Date, unidadeMedida: string): Observable<ItensContrato[]> {
-    return this.http.post<ItensContrato[]>(this.url + '/similares',
-      { termo: termos, data: dataInicioContrato, unidade: unidadeMedida });
-  }
+    getByContrato(idContrato: string): Observable<ItensContrato[]> {
+      return this.http.get<ItensContrato[]>(`${this.url}/contrato/${idContrato}`);
+    }
+
+    getItensSimilares(termos: string[], dataInicioContrato: Date): Observable<ItensContrato[]> {
+        return this.http.post<ItensContrato[]>(this.url + '/similares', { termo: termos, data: dataInicioContrato });
+    }
 
   getMediaItensSemelhantes(termos: string[], dataInicioContrato: Date, unidadeMedida: string) {
     const strTermos = [termos[0], termos.slice(0, 2).join(' & '), termos.join(' & ')];

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -29,8 +29,7 @@ export class ItensService {
     }
 
     getMediaItensSemelhantes(item: ItensContrato, termos: string[]): Observable<ItensContrato> {
-      const strTermos = [termos[0], termos.slice(0, 2).join(' & '), termos.join(' & ')];
-      return this.getItensSimilares(strTermos, item.dt_inicio_vigencia)
+      return this.getItensSimilares(termos, item.dt_inicio_vigencia)
         .pipe(take(1),
           map(itens => {
             const itensOrdenados = itens.slice(0, 21).sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);

--- a/client/src/app/shared/services/itens.service.ts
+++ b/client/src/app/shared/services/itens.service.ts
@@ -33,6 +33,9 @@ export class ItensService {
     return this.getItensSimilares(item, termos)
       .pipe(take(1),
         map(itens => {
+          if (itens.length === 0) {
+            return item;
+          }
           const itensOrdenados = itens.sort((a, b) => a.vl_item_contrato - b.vl_item_contrato);
           const meioInf = Math.floor((itensOrdenados.length - 1) / 2);
           const meioSup = Math.ceil((itensOrdenados.length - 1) / 2);

--- a/client/src/app/shared/services/lista.service.spec.ts
+++ b/client/src/app/shared/services/lista.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ListaService } from './lista.service';
+
+describe('ListaService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: ListaService = TestBed.get(ListaService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -15,7 +15,6 @@ class ListaService {
   private pDadosProcessados$ = new BehaviorSubject<any[]>([]);
 
   public dados$: Observable<any[]>;
-  public loading$ = new BehaviorSubject<boolean>(true);
 
   public estado: EstadoLista = {
     termoBusca: '',
@@ -25,11 +24,8 @@ class ListaService {
 
   constructor(public pipe: DecimalPipe) {
     this.busca$.pipe(
-      tap(() => this.loading$.next(true)),
-      debounceTime(0),
-      switchMap(() => this._buscar()),
-      delay(0),
-      tap(() => this.loading$.next(false))
+      debounceTime(200),
+      switchMap(() => this._buscar())
     ).subscribe(dados => {
       this.pDadosProcessados$.next(dados);
     });
@@ -92,6 +88,22 @@ export class ListaContratosService extends ListaService {
     return pipe.transform(dados.nr_contrato).includes(termo)
         || dados.nm_fornecedor.toLowerCase().includes(termo)
         || pipe.transform(dados.nr_documento_contratado).includes(termo);
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ListaLicitacoesService extends ListaService {
+
+  constructor(pipe: DecimalPipe) {
+    super(pipe);
+  }
+
+  corresponde(dados: any, texto: string) {
+    const termo = texto.toLowerCase();
+    return dados.descricao_objeto.toLowerCase().includes(termo)
+        || dados.status.toLowerCase().includes(termo);
   }
 }
 

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -11,42 +11,42 @@ import { EstadoLista, DirecaoOrd } from '../models/lista.model';
 })
 export class ListaService {
 
-  private _busca$ = new Subject<void>();
-  private _dadosProcessados$ = new BehaviorSubject<any[]>([]);
+  private busca$ = new Subject<void>();
+  private pDadosProcessados$ = new BehaviorSubject<any[]>([]);
 
   public dados$: Observable<any[]>;
   public loading$ = new BehaviorSubject<boolean>(true);
 
-  private _estado: EstadoLista = {
+  private estado: EstadoLista = {
     termoBusca: '',
     colunaOrd: '',
     direcaoOrd: ''
   };
 
   constructor(private pipe: DecimalPipe) {
-    this._busca$.pipe(
+    this.busca$.pipe(
       tap(() => this.loading$.next(true)),
       debounceTime(0),
       switchMap(() => this._buscar()),
       delay(0),
       tap(() => this.loading$.next(false))
     ).subscribe(dados => {
-      this._dadosProcessados$.next(dados);
+      this.pDadosProcessados$.next(dados);
     });
 
-    this._busca$.next();
+    this.busca$.next();
   }
 
-  get dadosProcessados$() { return this._dadosProcessados$.asObservable(); }
-  get termoBusca() { return this._estado.termoBusca; }
+  get dadosProcessados$() { return this.pDadosProcessados$.asObservable(); }
+  get termoBusca() { return this.estado.termoBusca; }
 
   set termoBusca(termoBusca: string) { this._set({termoBusca}); }
   set colunaOrd(colunaOrd: string) { this._set({colunaOrd}); }
   set direcaoOrd(direcaoOrd: DirecaoOrd) { this._set({direcaoOrd}); }
 
   private _set(patch: Partial<EstadoLista>) {
-    Object.assign(this._estado, patch);
-    this._busca$.next();
+    Object.assign(this.estado, patch);
+    this.busca$.next();
   }
 
   private comparar(v1, v2) {
@@ -73,7 +73,7 @@ export class ListaService {
   }
 
   private _buscar(): Observable<any[]> {
-    const {colunaOrd, direcaoOrd, termoBusca} = this._estado;
+    const {colunaOrd, direcaoOrd, termoBusca} = this.estado;
     return this.dados$
       .pipe(
         map(dados => this.ordenar(dados, colunaOrd, direcaoOrd)),

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -104,10 +104,11 @@ export class ListaLicitacoesService extends ListaService {
     super(pipe);
   }
 
-  corresponde(dados: any, texto: string) {
+  corresponde(dados: any, texto: string, pipe: PipeTransform) {
     const termo = texto.toLowerCase();
-    return dados.descricao_objeto.toLowerCase().includes(termo)
-        || dados.status.toLowerCase().includes(termo);
+    return pipe.transform(dados.nr_licitacao).includes(termo)
+      || dados.descricao_objeto.toLowerCase().includes(termo)
+      || dados.status.toLowerCase().includes(termo);
   }
 }
 

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -9,7 +9,7 @@ import { EstadoLista, DirecaoOrd } from '../models/lista.model';
 @Injectable({
   providedIn: 'root'
 })
-export class ListaService {
+class ListaService {
 
   private busca$ = new Subject<void>();
   private pDadosProcessados$ = new BehaviorSubject<any[]>([]);
@@ -17,13 +17,13 @@ export class ListaService {
   public dados$: Observable<any[]>;
   public loading$ = new BehaviorSubject<boolean>(true);
 
-  private estado: EstadoLista = {
+  public estado: EstadoLista = {
     termoBusca: '',
     colunaOrd: '',
     direcaoOrd: ''
   };
 
-  constructor(private pipe: DecimalPipe) {
+  constructor(public pipe: DecimalPipe) {
     this.busca$.pipe(
       tap(() => this.loading$.next(true)),
       debounceTime(0),
@@ -49,13 +49,13 @@ export class ListaService {
     this.busca$.next();
   }
 
-  private comparar(v1, v2) {
+  comparar(v1, v2) {
     v1 = !v1 ? '' : v1;
     v2 = !v2 ? '' : v2;
     return v1.toString().localeCompare(v2.toString(), 'pt', {numeric: true, ignorePunctuation: true});
   }
 
-  private ordenar(dados: any[], coluna: string, direcao: string): any[] {
+  ordenar(dados: any[], coluna: string, direcao: string): any[] {
     if (direcao === '') {
       return dados;
     } else {
@@ -64,12 +64,7 @@ export class ListaService {
     }
   }
 
-  private corresponde(dados: any, texto: string, pipe: PipeTransform) {
-    const termo = texto.toLowerCase();
-    dados.nm_fornecedor = dados.nm_fornecedor ? dados.nm_fornecedor : '';
-    return pipe.transform(dados.nr_contrato).includes(termo)
-        || dados.nm_fornecedor.toLowerCase().includes(termo)
-        || pipe.transform(dados.nr_documento_contratado).includes(termo);
+  corresponde(dados: any, texto: string, pipe: PipeTransform) {
   }
 
   private _buscar(): Observable<any[]> {
@@ -79,5 +74,33 @@ export class ListaService {
         map(dados => this.ordenar(dados, colunaOrd, direcaoOrd)),
         map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe)))
       );
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ListaContratosService extends ListaService {
+
+  constructor(pipe: DecimalPipe) {
+    super(pipe);
+  }
+
+  corresponde(dados: any, texto: string, pipe: PipeTransform) {
+    const termo = texto.toLowerCase();
+    dados.nm_fornecedor = dados.nm_fornecedor ? dados.nm_fornecedor : '';
+    return pipe.transform(dados.nr_contrato).includes(termo)
+        || dados.nm_fornecedor.toLowerCase().includes(termo)
+        || pipe.transform(dados.nr_documento_contratado).includes(termo);
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ListaItensService extends ListaService {
+
+  constructor(pipe: DecimalPipe) {
+    super(pipe);
   }
 }

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -2,7 +2,7 @@ import { Injectable, PipeTransform } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
 import { BehaviorSubject, Subject, Observable } from 'rxjs';
-import { tap, debounceTime, switchMap, delay, map } from 'rxjs/operators';
+import { debounceTime, switchMap, map } from 'rxjs/operators';
 
 import { EstadoLista, DirecaoOrd } from '../models/lista.model';
 
@@ -24,7 +24,7 @@ class ListaService {
 
   constructor(public pipe: DecimalPipe) {
     this.busca$.pipe(
-      debounceTime(200),
+      debounceTime(10),
       switchMap(() => this._buscar())
     ).subscribe(dados => {
       this.pDadosProcessados$.next(dados);
@@ -46,9 +46,13 @@ class ListaService {
   }
 
   comparar(v1, v2) {
-    v1 = !v1 ? '' : v1;
-    v2 = !v2 ? '' : v2;
-    return v1.toString().localeCompare(v2.toString(), 'pt', {numeric: true, ignorePunctuation: true});
+    if (typeof v1 === 'number') {
+      return v1 - v2;
+    } else {
+      v1 = !v1 ? '' : v1;
+      v2 = !v2 ? '' : v2;
+      return v1.toString().localeCompare(v2.toString(), 'pt', {numeric: true, ignorePunctuation: true});
+    }
   }
 
   ordenar(dados: any[], coluna: string, direcao: string): any[] {

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, PipeTransform } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+
+import { BehaviorSubject, Subject, Observable, of, combineLatest } from 'rxjs';
+import { tap, debounceTime, switchMap, delay, map } from 'rxjs/operators';
+
+import { EstadoLista, DirecaoOrd, ResultadoBusca } from '../models/lista.model';
+import { SubjectSubscriber } from 'rxjs/internal/Subject';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ListaService {
+
+  private _busca$ = new Subject<void>();
+  private _dadosProcessados$ = new BehaviorSubject<any[]>([]);
+
+  public dados$: Observable<any[]>;
+  public loading$ = new BehaviorSubject<boolean>(true);
+
+  private _estado: EstadoLista = {
+    termoBusca: '',
+    colunaOrd: '',
+    direcaoOrd: ''
+  };
+
+  constructor(private pipe: DecimalPipe) {
+    this._busca$.pipe(
+      tap(() => this.loading$.next(true)),
+      debounceTime(200),
+      switchMap(() => this._buscar()),
+      delay(200),
+      tap(() => this.loading$.next(false))
+    ).subscribe(dados => {
+      this._dadosProcessados$.next(dados);
+    });
+
+    this._busca$.next();
+  }
+
+  get dadosProcessados$() { return this._dadosProcessados$.asObservable(); }
+  get termoBusca() { return this._estado.termoBusca; }
+
+  set termoBusca(termoBusca: string) { this._set({termoBusca}); }
+  set colunaOrd(colunaOrd: string) { this._set({colunaOrd}); }
+  set direcaoOrd(direcaoOrd: DirecaoOrd) { this._set({direcaoOrd}); }
+
+  private _set(patch: Partial<EstadoLista>) {
+    Object.assign(this._estado, patch);
+    this._busca$.next();
+  }
+
+  private comparar(v1, v2) {
+    return v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+  }
+
+  private ordenar(dados: any[], coluna: string, direcao: string): any[] {
+    if (direcao === '') {
+      return dados;
+    } else {
+      return [...dados].sort((a, b) => {
+        const res = this.comparar(a[coluna], b[coluna]);
+        return direcao === 'asc' ? res : -res;
+      });
+    }
+  }
+
+  private corresponde(dados: any, texto: string, pipe: PipeTransform) {
+    const termo = texto.toLowerCase();
+    return pipe.transform(dados.nr_contrato).includes(termo)
+        || dados.contratoFornecedor.nm_pessoa.toLowerCase().includes(termo)
+        || pipe.transform(dados.nr_documento_contratado).includes(termo);
+  }
+
+  private _buscar(): Observable<any> {
+    const {colunaOrd, direcaoOrd, termoBusca} = this._estado;
+    return this.dados$.pipe(map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe))));
+    // // 1. sort
+    // let dados = this.ordenar(this._dados, colunaOrd, direcaoOrd);
+
+    // // 2. filter
+    // dados = dados.filter(country => this.corresponde(dados, termoBusca, this.pipe));
+  }
+}

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -1,11 +1,10 @@
 import { Injectable, PipeTransform } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
-import { BehaviorSubject, Subject, Observable, of, combineLatest } from 'rxjs';
+import { BehaviorSubject, Subject, Observable } from 'rxjs';
 import { tap, debounceTime, switchMap, delay, map } from 'rxjs/operators';
 
-import { EstadoLista, DirecaoOrd, ResultadoBusca } from '../models/lista.model';
-import { SubjectSubscriber } from 'rxjs/internal/Subject';
+import { EstadoLista, DirecaoOrd } from '../models/lista.model';
 
 @Injectable({
   providedIn: 'root'
@@ -27,9 +26,9 @@ export class ListaService {
   constructor(private pipe: DecimalPipe) {
     this._busca$.pipe(
       tap(() => this.loading$.next(true)),
-      debounceTime(200),
+      debounceTime(0),
       switchMap(() => this._buscar()),
-      delay(200),
+      delay(0),
       tap(() => this.loading$.next(false))
     ).subscribe(dados => {
       this._dadosProcessados$.next(dados);
@@ -72,9 +71,13 @@ export class ListaService {
         || pipe.transform(dados.nr_documento_contratado).includes(termo);
   }
 
-  private _buscar(): Observable<any> {
+  private _buscar(): Observable<any[]> {
     const {colunaOrd, direcaoOrd, termoBusca} = this._estado;
-    return this.dados$.pipe(map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe))));
+    return this.dados$
+      .pipe(
+        map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe))),
+        map(dados => this.ordenar(dados, colunaOrd, direcaoOrd))
+      );
     // // 1. sort
     // let dados = this.ordenar(this._dados, colunaOrd, direcaoOrd);
 

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -67,7 +67,7 @@ class ListaService {
   corresponde(dados: any, texto: string, pipe: PipeTransform) {
   }
 
-  private _buscar(): Observable<any[]> {
+  _buscar(): Observable<any[]> {
     const {colunaOrd, direcaoOrd, termoBusca} = this.estado;
     return this.dados$
       .pipe(
@@ -102,5 +102,13 @@ export class ListaItensService extends ListaService {
 
   constructor(pipe: DecimalPipe) {
     super(pipe);
+  }
+
+  _buscar(): Observable<any[]> {
+    const {colunaOrd, direcaoOrd, termoBusca} = this.estado;
+    return this.dados$
+      .pipe(
+        map(dados => this.ordenar(dados, colunaOrd, direcaoOrd))
+      );
   }
 }

--- a/client/src/app/shared/services/lista.service.ts
+++ b/client/src/app/shared/services/lista.service.ts
@@ -50,24 +50,25 @@ export class ListaService {
   }
 
   private comparar(v1, v2) {
-    return v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+    v1 = !v1 ? '' : v1;
+    v2 = !v2 ? '' : v2;
+    return v1.toString().localeCompare(v2.toString(), 'pt', {numeric: true, ignorePunctuation: true});
   }
 
   private ordenar(dados: any[], coluna: string, direcao: string): any[] {
     if (direcao === '') {
       return dados;
     } else {
-      return [...dados].sort((a, b) => {
-        const res = this.comparar(a[coluna], b[coluna]);
-        return direcao === 'asc' ? res : -res;
-      });
+      const dadosOrdenados = dados.sort((a, b) => this.comparar(a[coluna], b[coluna]));
+      return direcao === 'asc' ? dadosOrdenados : dadosOrdenados.reverse();
     }
   }
 
   private corresponde(dados: any, texto: string, pipe: PipeTransform) {
     const termo = texto.toLowerCase();
+    dados.nm_fornecedor = dados.nm_fornecedor ? dados.nm_fornecedor : '';
     return pipe.transform(dados.nr_contrato).includes(termo)
-        || dados.contratoFornecedor.nm_pessoa.toLowerCase().includes(termo)
+        || dados.nm_fornecedor.toLowerCase().includes(termo)
         || pipe.transform(dados.nr_documento_contratado).includes(termo);
   }
 
@@ -75,13 +76,8 @@ export class ListaService {
     const {colunaOrd, direcaoOrd, termoBusca} = this._estado;
     return this.dados$
       .pipe(
-        map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe))),
-        map(dados => this.ordenar(dados, colunaOrd, direcaoOrd))
+        map(dados => this.ordenar(dados, colunaOrd, direcaoOrd)),
+        map(dados => dados.filter(d => this.corresponde(d, termoBusca, this.pipe)))
       );
-    // // 1. sort
-    // let dados = this.ordenar(this._dados, colunaOrd, direcaoOrd);
-
-    // // 2. filter
-    // dados = dados.filter(country => this.corresponde(dados, termoBusca, this.pipe));
   }
 }

--- a/client/tslint.json
+++ b/client/tslint.json
@@ -86,6 +86,6 @@
     "use-pipe-transform-interface": true
   },
   "rulesDirectory": [
-    "codelyzer"
+    "./node_modules/codelyzer"
   ]
 }

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -26,7 +26,12 @@ router.get("/vigentes", (req, res) => {
   const municipio = req.query.nome_municipio;
 
   Contrato.findAll({
-    attributes: ["id_contrato", "id_licitacao", "nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia"],
+    raw: true,
+    attributes: {
+      include: [[Sequelize.col('contratoFornecedor.nm_pessoa'), 'nm_fornecedor'],
+                [Sequelize.col('contratoFornecedor.tp_pessoa'), 'tp_fornecedor'],
+                "id_contrato", "id_licitacao", "nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia"]
+    },
     include: [
       {
         attributes: ["nome_municipio"],
@@ -39,7 +44,7 @@ router.get("/vigentes", (req, res) => {
       },
       {
         model: Fornecedor,
-        attributes: ["nm_pessoa", "tp_pessoa"],
+        attributes: [],
         as: "contratoFornecedor"
       }
     ],

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -63,6 +63,29 @@ router.get("/vigentes", (req, res) => {
     .catch(err => res.status(BAD_REQUEST).json({ err }));
 });
 
+router.get("/licitacao/:id", (req, res) => {
+  Contrato.findAll({
+    raw: true,
+    attributes: {
+      include: [[Sequelize.col('contratoFornecedor.nm_pessoa'), 'nm_fornecedor'],
+                [Sequelize.col('contratoFornecedor.tp_pessoa'), 'tp_fornecedor'],
+                "id_contrato", "id_licitacao", "nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia"]
+    },
+    include: [
+      {
+        model: Fornecedor,
+        attributes: [],
+        as: "contratoFornecedor"
+      }
+    ],
+    where: {
+      id_licitacao: req.params.id
+    }
+  })
+  .then(contratos => res.status(SUCCESS).json(contratos))
+  .catch(err => res.status(BAD_REQUEST).json({ err }));
+});
+
 router.get("/:id", (req, res) => {
   Contrato.findOne({
     include: [
@@ -109,94 +132,6 @@ router.get("/:id", (req, res) => {
       console.log(err)
       res.status(BAD_REQUEST).json({ err })
     });
-});
-
-router.get("/licitacao/:id", (req, res) => {
-  Contrato.findAll({
-    attributes: ["id_contrato", "nr_contrato", "nr_documento_contratado", "vl_contrato", "dt_inicio_vigencia", "dt_final_vigencia", "ano_contrato"],
-    include: [
-      {
-        model: Fornecedor,
-        attributes: ["nm_pessoa", "tp_pessoa"],
-        as: "contratoFornecedor"
-      },
-      {
-        model: itensContrato,
-        include: [
-          {
-            model: itensLicitacao,
-            attributes: ["vl_unitario_estimado", "sg_unidade_medida"],
-            as: "itensLicitacaoItensContrato"
-          }
-        ],
-        attributes: ["qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item", "categoria", "ano_licitacao", "dt_inicio_vigencia"],
-        as: "itensContrato"
-      },
-      {
-        model: Novidade,
-        attributes: ["id_tipo", [sequelize.literal('CAST(texto_novidade as REAL)'), 'valor']],
-        required: false,
-        as: "contratoNovidade",
-        where: {
-          id_tipo: {
-            [Op.or]: [6, 9] // 6 (novidade de pagamento) e 9 (novidade de empenho)
-          }
-        }
-      }
-    ],
-    where: {
-      id_licitacao: req.params.id
-    }
-  })
-    .then(contratos => {
-
-      contratos = contratos.map(contrato => {
-        let data = contrato.toJSON();
-
-        if (data.contratoNovidade && data.contratoNovidade.length > 0) {
-          data.total_pago = data.contratoNovidade
-            .map(item => item.valor)
-            .reduce((prev, next) => prev + next);
-        } else {
-          data.total_pago = 0;
-        }
-
-        return data;
-      })
-
-      res.json(contratos)
-    })
-    .catch(err => {
-      console.log(err)
-      res.status(BAD_REQUEST).json({ err })
-    });
-});
-
-router.get("/licitacao/:id/fornecedores", (req, res) => {
-  Fornecedor.findAll({
-    attributes: ["nr_documento", "nm_pessoa", "tp_pessoa"],
-    include: [
-      {
-        attributes: ["nr_contrato", "ano_contrato", "vl_contrato", "id_contrato"],
-        model: Contrato,
-        as: "fornecedorContratos",
-        where: {
-          id_licitacao: req.params.id
-        }
-      }
-    ],
-  })
-    .then(fornecedores => {
-      fornecedores = fornecedores.map(f => f.get({ plain: true }));
-
-      fornecedores.forEach((value) => {
-        value.total_contratado = value.fornecedorContratos
-          .reduce((a, b) => a + (b["vl_contrato"] || 0), 0);
-      });
-
-      res.status(SUCCESS).json(fornecedores)
-    })
-    .catch(err => res.status(BAD_REQUEST).json({ err: err.message }));
 });
 
 module.exports = router;

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -81,18 +81,6 @@ router.get("/:id", (req, res) => {
             [Op.or]: [6, 9] // 6 (novidade de pagamento) e 9 (novidade de empenho)
           }
         }
-      },
-      {
-        model: itensContrato,
-        include: [
-          {
-            model: itensLicitacao,
-            attributes: ["vl_unitario_estimado", "sg_unidade_medida"],
-            as: "itensLicitacaoItensContrato"
-          }
-        ],
-        attributes: ["id_item_contrato", "qt_itens_contrato", "vl_item_contrato", "vl_total_item_contrato", "ds_item", "categoria", "ano_licitacao", "dt_inicio_vigencia", "sg_unidade_medida"],
-        as: "itensContrato"
       }
     ],
     where: {
@@ -183,7 +171,6 @@ router.get("/licitacao/:id", (req, res) => {
       res.status(BAD_REQUEST).json({ err })
     });
 });
-
 
 router.get("/licitacao/:id/fornecedores", (req, res) => {
   Fornecedor.findAll({

--- a/server/routes/api/contratos.js
+++ b/server/routes/api/contratos.js
@@ -108,12 +108,7 @@ router.get("/:id", (req, res) => {
     ],
     where: {
       id_contrato: req.params.id
-    },
-    order: [[
-      { model: itensContrato, as: 'itensContrato' },
-      'id_item_contrato',
-      'DESC'
-    ]]
+    }
   })
     .then(contrato => {
       contrato = contrato.get({ plain: true });

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -96,6 +96,7 @@ router.post("/similares", (req, res) => {
                       AND ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) >= 0.65\
                       ORDER BY ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) DESC, id_item_contrato ASC \
                       LIMIT 21;`
+  
   models.sequelize.query(query, {
     model: itensContrato,
     mapToModel: true

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -96,7 +96,6 @@ router.post("/similares", (req, res) => {
                       AND ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) >= 0.65\
                       ORDER BY ts_rank(item_search.document, to_tsquery('portuguese', '${termoRanking}')) DESC, id_item_contrato ASC \
                       LIMIT 21;`
-  
   models.sequelize.query(query, {
     model: itensContrato,
     mapToModel: true

--- a/server/routes/api/itensContrato.js
+++ b/server/routes/api/itensContrato.js
@@ -3,6 +3,7 @@ const express = require("express");
 const router = express.Router();
 
 const models = require("../../models/index");
+const { Sequelize } = require("sequelize");
 
 const itensContrato = models.itensContrato;
 const Orgao = models.orgao;
@@ -35,6 +36,20 @@ router.get("/item/:id", (req, res) => {
 // Recupera itens de contrato a partir do id do contrato
 router.get("/contrato/:id", (req, res) => {
   itensContrato.findAll({
+    raw: true,
+    attributes: {
+      include: [
+        [Sequelize.col('itensLicitacaoItensContrato.vl_unitario_estimado'), 'vl_unitario_estimado'],
+        [Sequelize.col('itensLicitacaoItensContrato.sg_unidade_medida'), 'sg_unidade_medida']
+      ]
+    },
+    include: [
+      {
+        model: itensLicitacao,
+        attributes: [],
+        as: "itensLicitacaoItensContrato"
+      }
+    ],
     where: {
       id_contrato: req.params.id
     }

--- a/server/routes/api/licitacoes.js
+++ b/server/routes/api/licitacoes.js
@@ -26,6 +26,11 @@ router.get("/municipio/:nome_municipio", (req, res) => {
   Licitacao.findAll({
     include: [
       {
+        model: Contrato,
+        attributes: ["vl_contrato"],
+        as: "contratosLicitacao"
+      },
+      {
         attributes: ["nome_municipio"],
         model: Orgao,
         as: "licitacoesOrgao",


### PR DESCRIPTION
- Muda status da licitação para com/sem contratos
- Limita itens semelhantes para 21 no backend
- Filtra itens por unidade
- Adiciona colunas de número da licitação e total contratado
- Adiciona carregamento para tabela de itens de um contrato
- Resolve alguns bugs

**Atenção**: depende de aceitação do PR #122 