### PR TITLE
Cria query de consulta por objeto do contrato

### DIFF
--- a/server/models/postgres/contrato.js
+++ b/server/models/postgres/contrato.js
@@ -27,7 +27,8 @@ module.exports = (sequelize, type) => {
         descricao_objeto_contrato: type.STRING,
         justificativa_contratacao: type.STRING,
         obs_contrato: type.STRING,
-        tipo_instrumento_contrato: type.STRING
+        tipo_instrumento_contrato: type.STRING,
+        language: type.STRING
 
       },
       {


### PR DESCRIPTION
Para testar: http://localhost:5000/api/contratos/search?termo=<termo que será buscado no objeto do contrato>