### PR TITLE
Revisão de textos no site

### DIFF
--- a/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
+++ b/client/src/app/fornecedores/info-fornecedor/info-fornecedor.component.html
@@ -10,7 +10,7 @@
         <div class="dados-linha">
           <strong>Data da primeira compra</strong>
           <app-tooltip-ajuda [posicao]="'top'" [descricao]="
-              'Data em que o fornecedor teve seu primeiro contrato com uma prefeitura ou outros órgãos públicos no estado.'
+              'Data em que o fornecedor teve sua primeira compra com uma prefeitura ou outros órgãos públicos no estado.'
             ">
           </app-tooltip-ajuda>
         </div>
@@ -24,7 +24,7 @@
           <strong>Total de compras</strong>
 
           <app-tooltip-ajuda [posicao]="'top'" [descricao]="
-              'Quantidade de contratos fechados entre este fornecedor e órgãos públicos no estado.'
+              'Quantidade de compras fechadas entre este fornecedor e órgãos públicos no estado.'
             ">
           </app-tooltip-ajuda>
         </div>
@@ -187,7 +187,7 @@
       <div class="col-lg-6">
         <form>
           <div class="form-group">
-            <input class="form-control" type="text" placeholder="Buscar nos contratos..." name="termoBusca"
+            <input class="form-control" type="text" placeholder="Buscar nas compras..." name="termoBusca"
               [(ngModel)]="listaService.termoBusca">
           </div>
         </form>

--- a/client/src/app/itens/info-item/info-item.component.html
+++ b/client/src/app/itens/info-item/info-item.component.html
@@ -90,7 +90,7 @@
                 ordenavel="ano_licitacao"
                 (ordenar)="onOrdenar($event)"
                 appOrdenavel>
-                Contrato
+                Compra
               </th>
               <th
                 scope="col"

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.html
@@ -10,7 +10,7 @@
       <div class="col">
         <span
           class="badge"
-          [ngClass]="licitacao?.status === 'Com contratos' ? 'badge-danger' : 'badge-info'">
+          [ngClass]="licitacao?.status === 'Com compras' ? 'badge-danger' : 'badge-info'">
           {{ licitacao?.status }}
         </span>
         <div

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.ts
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-info/licitacoes-detalhar-info.component.ts
@@ -40,7 +40,7 @@ export class LicitacoesDetalharInfoComponent implements OnInit, OnDestroy {
     ).pipe(takeUntil(this.unsubscribe)).subscribe(data => {
       this.licitacao = data[0];
       this.licitacao.qt_contratos = this.licitacao.contratosLicitacao.length;
-      this.licitacao.status = this.licitacao.qt_contratos === 0 ? 'Sem contratos' : 'Com contratos';
+      this.licitacao.status = this.licitacao.qt_contratos === 0 ? 'Sem compras' : 'Com compras';
       this.licitacao.vl_contratado = this.licitacao.contratosLicitacao
         .reduce((sum, contrato) => sum + contrato.vl_contrato, 0);
       const novidadesLicitacao = data[1];

--- a/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-itens/licitacoes-detalhar-itens.component.html
+++ b/client/src/app/licitacoes/licitacoes-detalhar/licitacoes-detalhar-itens/licitacoes-detalhar-itens.component.html
@@ -83,7 +83,7 @@
                             <span class="nowrap">no estado</span>
                             <br>
                             (R$)
-                            <app-tooltip-ajuda [descricao]="'Mediana do preço de produtos similares contratados em municípios do estado seis meses antes ou depois da data do contrato'"></app-tooltip-ajuda>
+                            <app-tooltip-ajuda [descricao]="'Mediana do preço de produtos similares contratados em municípios do estado seis meses antes ou depois da data da compra'"></app-tooltip-ajuda>
                         </th>
                         <th
                             scope="col"

--- a/client/src/app/municipio/municipio.component.html
+++ b/client/src/app/municipio/municipio.component.html
@@ -1,6 +1,7 @@
 <div class="view-container">
   <app-barra-titulo
-    [titulo]="municipioEscolhido | titlecase"
+    *ngIf="municipioEscolhido"
+    titulo="{{ municipioEscolhido | titlecase }} – RS"
     [exibirVoltar]="false"></app-barra-titulo>
 
   <div class="container">


### PR DESCRIPTION
## Mudanças
-  Muda referências a contratos para compras nas páginas da licitação e do fornecedor e de um item.
- Adiciona estado default para o nome do município na página do município 

Fixes #163, #189, #191 